### PR TITLE
Move Ditto management into DittoViewModel

### DIFF
--- a/android-java/app/src/main/java/com/example/dittotasks/DittoViewModel.java
+++ b/android-java/app/src/main/java/com/example/dittotasks/DittoViewModel.java
@@ -1,0 +1,129 @@
+package com.example.dittotasks;
+
+import android.app.Application;
+
+import androidx.lifecycle.AndroidViewModel;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.stream.Collectors;
+
+import kotlin.Unit;
+import live.ditto.Ditto;
+import live.ditto.DittoDependencies;
+import live.ditto.DittoError;
+import live.ditto.DittoIdentity;
+import live.ditto.DittoStoreObserver;
+import live.ditto.DittoSyncSubscription;
+import live.ditto.android.DefaultAndroidDittoDependencies;
+
+public class DittoViewModel extends AndroidViewModel {
+    private final TaskAdapter taskAdapter;
+    private Ditto ditto;
+    private DittoSyncSubscription taskSubscription;
+    private DittoStoreObserver taskObserver;
+
+    public static final String DITTO_APP_ID = "";
+    public static final String DITTO_PLAYGROUND_TOKEN = "";
+
+    public DittoViewModel(Application application) {
+        super(application);
+        this.taskAdapter = new TaskAdapter();
+        initDitto();
+    }
+
+    @Override
+    protected void onCleared() {
+        super.onCleared();
+        ditto.close();
+    }
+
+    private void initDitto() {
+        try {
+            DittoDependencies androidDependencies = new DefaultAndroidDittoDependencies(getApplication().getApplicationContext());
+            var identity = new DittoIdentity.OnlinePlayground(androidDependencies, DITTO_APP_ID, DITTO_PLAYGROUND_TOKEN);
+            ditto = new Ditto(androidDependencies, identity);
+            ditto.disableSyncWithV3();
+            ditto.startSync();
+
+            taskSubscription = ditto.sync.registerSubscription("SELECT * FROM tasks");
+            taskObserver = ditto.store.registerObserver("SELECT * FROM tasks WHERE deleted=false ORDER BY _id", null, result -> {
+                var tasks = result.getItems().stream().map(Task::fromQueryItem).collect(Collectors.toCollection(ArrayList::new));
+                taskAdapter.setTasks(new ArrayList<>(tasks));
+                return Unit.INSTANCE;
+            });
+        } catch (DittoError e) {
+            e.printStackTrace();
+        }
+    }
+
+    public TaskAdapter getTaskAdapter() {
+        return taskAdapter;
+    }
+
+    public void createTask(String title) {
+        HashMap<String, Object> task = new HashMap<>();
+        task.put("title", title);
+        task.put("done", false);
+        task.put("deleted", false);
+
+        HashMap<String, Object> args = new HashMap<>();
+        args.put("task", task);
+        try {
+            ditto.store.execute("INSERT INTO tasks DOCUMENTS (:task)", args);
+        } catch (DittoError e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void editTaskTitle(Task task, String newTitle) {
+        HashMap<String, Object> args = new HashMap<>();
+        args.put("id", task.getId());
+        args.put("title", newTitle);
+
+        try {
+            ditto.store.execute("UPDATE tasks SET title=:title WHERE _id=:id", args);
+        } catch (DittoError e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void toggleTask(Task task) {
+        HashMap<String, Object> args = new HashMap<>();
+        args.put("id", task.getId());
+        args.put("done", !task.isDone());
+
+        try {
+            ditto.store.execute("UPDATE tasks SET done=:done WHERE _id=:id", args);
+        } catch (DittoError e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void deleteTask(Task task) {
+        HashMap<String, Object> args = new HashMap<>();
+        args.put("id", task.getId());
+        try {
+            ditto.store.execute("UPDATE tasks SET deleted=true WHERE _id=:id", args);
+        } catch (DittoError e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void toggleSync() {
+        if (ditto == null) {
+            return;
+        }
+
+        boolean isSyncActive = ditto.isSyncActive();
+        try {
+            if (isSyncActive) {
+                ditto.stopSync();
+            } else {
+                ditto.startSync();
+            }
+        } catch (DittoError e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/android-java/app/src/main/java/com/example/dittotasks/MainActivity.java
+++ b/android-java/app/src/main/java/com/example/dittotasks/MainActivity.java
@@ -1,7 +1,9 @@
 package com.example.dittotasks;
 
+import static com.example.dittotasks.DittoViewModel.DITTO_APP_ID;
+import static com.example.dittotasks.DittoViewModel.DITTO_PLAYGROUND_TOKEN;
+
 import android.app.AlertDialog;
-import android.content.res.ColorStateList;
 import android.os.Bundle;
 import android.view.View;
 import android.view.WindowManager;
@@ -11,43 +13,26 @@ import android.widget.TextView;
 import androidx.activity.ComponentActivity;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.SwitchCompat;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
-import kotlin.Unit;
-import live.ditto.Ditto;
-import live.ditto.DittoDependencies;
-import live.ditto.DittoError;
-import live.ditto.DittoIdentity;
-import live.ditto.DittoStoreObserver;
-import live.ditto.DittoSyncSubscription;
-import live.ditto.android.DefaultAndroidDittoDependencies;
 import live.ditto.transports.DittoSyncPermissions;
 
 public class MainActivity extends ComponentActivity {
-    private TaskAdapter taskAdapter;
-    private SwitchCompat syncSwitch;
-
-    Ditto ditto;
-    DittoSyncSubscription taskSubscription;
-    DittoStoreObserver taskObserver;
-
-    private String DITTO_APP_ID = "";
-    private String DITTO_PLAYGROUND_TOKEN = "";
+    DittoViewModel dittoViewModel;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-        initDitto();
+
+        dittoViewModel = new ViewModelProvider(this).get(DittoViewModel.class);
 
         // Populate AppID view
         TextView appId = findViewById(R.id.ditto_app_id);
@@ -62,47 +47,23 @@ public class MainActivity extends ComponentActivity {
         addButton.setOnClickListener(v -> showAddTaskModal());
 
         // Initialize sync switch
-        syncSwitch = findViewById(R.id.sync_switch);
+        SwitchCompat syncSwitch = findViewById(R.id.sync_switch);
         syncSwitch.setChecked(true);
         syncSwitch.setOnCheckedChangeListener(((buttonView, isChecked) -> {
-            toggleSync();
+            dittoViewModel.toggleSync();
         }));
 
         // Initialize task list
         RecyclerView taskList = findViewById(R.id.task_list);
         taskList.setLayoutManager(new LinearLayoutManager(this));
-        taskAdapter = new TaskAdapter();
+        TaskAdapter taskAdapter = dittoViewModel.getTaskAdapter();
         taskList.setAdapter(taskAdapter);
         taskAdapter.setOnTaskToggleListener((task, isChecked) -> {
-            toggleTask(task);
+            dittoViewModel.toggleTask(task);
         });
-        taskAdapter.setOnTaskDeleteListener(this::deleteTask);
+        taskAdapter.setOnTaskDeleteListener(dittoViewModel::deleteTask);
         taskAdapter.setOnTaskLongPressListener(this::showEditTaskModal);
         taskAdapter.setTasks(List.of());
-    }
-
-    void initDitto() {
-        requestPermissions();
-
-        try {
-            DittoDependencies androidDependencies = new DefaultAndroidDittoDependencies(getApplicationContext());
-            var identity = new DittoIdentity.OnlinePlayground(androidDependencies, DITTO_APP_ID, DITTO_PLAYGROUND_TOKEN);
-            ditto = new Ditto(androidDependencies, identity);
-            ditto.disableSyncWithV3();
-
-            taskSubscription = ditto.sync.registerSubscription("SELECT * FROM tasks");
-            taskObserver = ditto.store.registerObserver("SELECT * FROM tasks WHERE deleted=false ORDER BY _id", null, result -> {
-                var tasks = result.getItems().stream().map(Task::fromQueryItem).collect(Collectors.toCollection(ArrayList::new));
-                runOnUiThread(() -> {
-                    taskAdapter.setTasks(new ArrayList<>(tasks));
-                });
-                return Unit.INSTANCE;
-            });
-
-            ditto.startSync();
-        } catch (DittoError e) {
-            e.printStackTrace();
-        }
     }
 
     // Request permissions for Ditto
@@ -111,77 +72,6 @@ public class MainActivity extends ComponentActivity {
         String[] missing = permissions.missingPermissions(permissions.requiredPermissions());
         if (missing.length > 0) {
             this.requestPermissions(missing, 0);
-        }
-    }
-
-    private void createTask(String title) {
-        HashMap<String, Object> task = new HashMap<>();
-        task.put("title", title);
-        task.put("done", false);
-        task.put("deleted", false);
-
-        HashMap<String, Object> args = new HashMap<>();
-        args.put("task", task);
-        try {
-            ditto.store.execute("INSERT INTO tasks DOCUMENTS (:task)", args);
-        } catch (DittoError e) {
-            e.printStackTrace();
-        }
-    }
-
-    private void editTaskTitle(Task task, String newTitle) {
-        HashMap<String, Object> args = new HashMap<>();
-        args.put("id", task.getId());
-        args.put("title", newTitle);
-
-        try {
-            ditto.store.execute("UPDATE tasks SET title=:title WHERE _id=:id", args);
-        } catch (DittoError e) {
-            e.printStackTrace();
-        }
-    }
-
-    private void toggleTask(Task task) {
-        HashMap<String, Object> args = new HashMap<>();
-        args.put("id", task.getId());
-        args.put("done", !task.isDone());
-
-        try {
-            ditto.store.execute("UPDATE tasks SET done=:done WHERE _id=:id", args);
-        } catch (DittoError e) {
-            e.printStackTrace();
-        }
-    }
-
-    private void deleteTask(Task task) {
-        HashMap<String, Object> args = new HashMap<>();
-        args.put("id", task.getId());
-        try {
-            ditto.store.execute("UPDATE tasks SET deleted=true WHERE _id=:id", args);
-        } catch (DittoError e) {
-            e.printStackTrace();
-        }
-    }
-
-    private void toggleSync() {
-        if (ditto == null) {
-            return;
-        }
-
-        boolean isSyncActive = ditto.isSyncActive();
-        var nextColor = isSyncActive ? null : ColorStateList.valueOf(0xFFBB86FC);
-        var nextText = isSyncActive ? "Sync Inactive" : "Sync Active";
-        try {
-            if (isSyncActive) {
-                ditto.stopSync();
-            } else {
-                ditto.startSync();
-            }
-            syncSwitch.setChecked(!isSyncActive);
-            syncSwitch.setTrackTintList(nextColor);
-            syncSwitch.setText(nextText);
-        } catch (DittoError e) {
-            e.printStackTrace();
         }
     }
 
@@ -194,7 +84,7 @@ public class MainActivity extends ComponentActivity {
                 .setPositiveButton("Add", (dialog, which) -> {
                     String text = modalTaskTitle.getText().toString().trim();
                     if (!text.isEmpty()) {
-                        createTask(text);
+                        dittoViewModel.createTask(text);
                     }
                 })
                 .setNegativeButton("Cancel", (dialog, which) -> dialog.cancel());
@@ -221,7 +111,7 @@ public class MainActivity extends ComponentActivity {
                 .setPositiveButton("Save", (dialog, which) -> {
                     String newTitle = modalEditTaskTitle.getText().toString().trim();
                     if (!newTitle.isEmpty()) {
-                        editTaskTitle(task, newTitle);
+                        dittoViewModel.editTaskTitle(task, newTitle);
                     }
                 })
                 .setNegativeButton("Cancel", (dialog, which) -> dialog.cancel());


### PR DESCRIPTION
This is a continuation of work started in https://github.com/getditto/quickstart/pull/11, the objective being to move Ditto logic into an Android ViewModel. Unfortunately, this is currently causing strange errors that I haven't been able to debug, involving a crash in the Ditto core. Therefore, I pulled these changes into their own PR to unblock the initial merging of the android-java quickstart.