### PR TITLE
Add comments about use of temporary persistence directory in TUI apps

### DIFF
--- a/dotnet-tui/DittoDotNetTasksConsole/Program.cs
+++ b/dotnet-tui/DittoDotNetTasksConsole/Program.cs
@@ -44,6 +44,9 @@ public static class Program
         }
     }
 
+    /// <summary>
+    /// Reads values from the embedded .env file resource.
+    /// </summary>
     private static Dictionary<string, string> LoadEnvVariables()
     {
         var envVars = new Dictionary<string, string>();

--- a/dotnet-tui/DittoDotNetTasksConsole/TasksPeer.cs
+++ b/dotnet-tui/DittoDotNetTasksConsole/TasksPeer.cs
@@ -49,6 +49,13 @@ public class TasksPeer : IDisposable
         AppId = appId;
         PlaygroundToken = playgroundToken;
 
+        // We use a temporary directory to store Ditto's local database.  This
+        // means that data will not be persistent between runs of the
+        // application, but it allows us to run multiple instances of the
+        // application concurrently on the same machine.  For a production
+        // application, we would want to store the database in a more permanent
+        // location, and if multiple instances are needed, ensure that each
+        // instance has its own persistence directory.
         var tempDir = Path.Combine(
             Path.GetTempPath(),
             "DittoDotNetTasksConsole-" + Guid.NewGuid().ToString());

--- a/javascript-tui/source/cli.js
+++ b/javascript-tui/source/cli.js
@@ -32,6 +32,13 @@ const cli = meow(
 
 console.log("Flags:", cli.flags);
 
+// We use a temporary directory to store Ditto's local database.  This
+// means that data will not be persistent between runs of the
+// application, but it allows us to run multiple instances of the
+// application concurrently on the same machine.  For a production
+// application, we would want to store the database in a more permanent
+// location, and if multiple instances are needed, ensure that each
+// instance has its own persistence directory.
 const tempdir = temporaryDirectory();
 
 // Grab appID and token from CLI or .env in that order

--- a/rust-tui/src/bin/main.rs
+++ b/rust-tui/src/bin/main.rs
@@ -77,6 +77,13 @@ async fn main() -> Result<()> {
 }
 
 fn try_init_ditto(app_id: AppId, token: String) -> Result<Ditto> {
+    // We use a temporary directory to store Ditto's local database.  This
+    // means that data will not be persistent between runs of the
+    // application, but it allows us to run multiple instances of the
+    // application concurrently on the same machine.  For a production
+    // application, we would want to store the database in a more permanent
+    // location, and if multiple instances are needed, ensure that each
+    // instance has its own persistence directory.
     let ditto = Ditto::builder()
         .with_root(Arc::new(TempRoot::new()))
         .with_identity(|root| OnlinePlayground::new(root, app_id.clone(), token, true, None))?


### PR DESCRIPTION
@busec0 suggested in https://github.com/getditto/quickstart/pull/21#discussion_r1943135766 that our use of temporary directories as persistence directories may mislead new Ditto developers into thinking that was a best practice.  I've added comments explaining why developers may want to use permanent persistence directories.