### PR TITLE
Update Flutter Quick Start to use 4.9.1 Public Preview

### DIFF
--- a/flutter_quickstart/README.md
+++ b/flutter_quickstart/README.md
@@ -31,10 +31,10 @@ flutter pub get
 ### 3. Configure Ditto
 
 #### Obtain App ID and Playground Token
+
 - Log in to your Ditto Portal account
 - Navigate to your application and obtain the App ID and Playground Token (see [Sync Credentials](https://docs.ditto.live/get-started/sync-credentials)
- for more details)
-
+  for more details)
 
 #### Update Flutter Application with Ditto Credentials
 
@@ -45,7 +45,6 @@ flutter pub get
 const appID = "REPLACE_ME_WITH_YOUR_APP_ID";
 const token = "REPLACE_ME_WITH_YOUR_PLAYGROUND_TOKEN";
 ```
-
 
 ### 4. Run the Application
 
@@ -66,16 +65,14 @@ flutter run
 Please choose one (or "q" to quit):
 ```
 
-
 #### Run the Application on iOS
 
 - Ensure you have an iOS Simulator running or connect a physical iOS device
-Run the following command in the terminal and select the iOS Simulator/Device
+  Run the following command in the terminal and select the iOS Simulator/Device
 
 ```bash
 flutter run
 ```
-
 
 - Select the iOS Simulator/Device
 
@@ -85,6 +82,15 @@ flutter run
 Please choose one (or "q" to quit):
 ```
 
+#### Run the Application on Web
+
+- Run the following command in the terminal
+
+```bash
+flutter run -d chrome
+```
+
+The application will open in Google Chrome.
 
 ### 5. Sync-Data Offline
 
@@ -92,7 +98,9 @@ Please choose one (or "q" to quit):
 - Disconnect from your current WiFi network while keeping WiFi enabled on the device to allow for LAN connections
 - Create new Tasks and update the Done status of existing tasks
 
-*Note: Android Emulators cannot connect to iOS Simulators for offline sync due to platform limitations*
+_Note: Android Emulators cannot connect to iOS Simulators for offline sync due to platform limitations_
+
+_Note: Flutter Web only supports syncing with the Ditto cloud, and offline sync is not supported_
 
 # Additional Resources
 
@@ -107,6 +115,7 @@ Explore the following links and resources to learn more about Ditto:
 - [Ditto Flutter Roadmap](https://docs.ditto.live/flutter/roadmap)
 
 #### Technical Information
+
 - [Ditto Data Store CRUD](https://docs.ditto.live/crud/create)
 - [Ditto Data Sync Subscriptions](https://docs.ditto.live/sync/subscriptions-management)
 - [Ditto Query Language](https://docs.ditto.live/dql)


### PR DESCRIPTION
**Do not merge.** 

This is a temporary PR that updates the Flutter quick start app to use SDK version `4.9.1-experimental-web.0`.