### PR TITLE
dotnet-tui: Add sleep-when-idle handler

### DIFF
--- a/dotnet-tui/DittoDotNetTasksConsole/Program.cs
+++ b/dotnet-tui/DittoDotNetTasksConsole/Program.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 
 using DittoSDK;
@@ -36,6 +37,14 @@ public static class Program
         {
             Application.Init();
             Application.Top.Add(new TasksWindow(peer));
+
+            // Sleep when idle, reducing CPU usage.
+            Application.MainLoop.AddIdle(() =>
+            {
+                Thread.Sleep(50);
+                return true;
+            });
+
             Application.Run();
         }
         finally


### PR DESCRIPTION
Adds a `Thread.Sleep(50)` to the Terminal.Gui main loop idle handler, reducing CPU usage.

The app was always using 100% CPU before this change. Now it only uses a few percent.