### PR TITLE
README.md: Change "Getting Started" link to "Quickstarts" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repo contains apps that demonstrate how to use the Ditto SDK for supported
 programming languages and platforms.
 
-See Ditto's [Getting Started](https://docs.ditto.live/home/introduction)
+See Ditto's [Quickstarts](https://docs.ditto.live/sdk/latest/quickstarts)
 documentation for more information.
 
 For support, please contact Ditto Support (<support@ditto.live>).


### PR DESCRIPTION
Changes the documentation link to `[Quickstarts](https://docs.ditto.live/sdk/latest/quickstarts)` after review by Skyler Jokiel.