### PR TITLE
Flutter tweaks for web compatibility

### DIFF
--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -1,12 +1,9 @@
-import 'dart:io';
-
 import 'package:ditto_live/ditto_live.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_quickstart/dialog.dart';
 import 'package:flutter_quickstart/dql_builder.dart';
 import 'package:flutter_quickstart/task.dart';
 import 'package:flutter/material.dart';
-import 'package:path_provider/path_provider.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 const appID = "<replace with your app ID>";
@@ -40,10 +37,9 @@ class _DittoExampleState extends State<DittoExample> {
   /// 1. Requests required Bluetooth and WiFi permissions on non-web platforms
   /// 2. Initializes the Ditto SDK
   /// 3. Sets up online playground identity with the provided app ID and token
-  /// 4. Creates and configures persistence directory for local data storage
-  /// 5. Enables peer-to-peer communication on non-web platforms
-  /// 6. Configures WebSocket connection to Ditto cloud
-  /// 7. Starts sync and updates the app state with the configured Ditto instance
+  /// 4. Enables peer-to-peer communication on non-web platforms
+  /// 5. Configures WebSocket connection to Ditto cloud
+  /// 6. Starts sync and updates the app state with the configured Ditto instance
   Future<void> _initDitto() async {
     if (!kIsWeb) {
       await [
@@ -59,25 +55,13 @@ class _DittoExampleState extends State<DittoExample> {
     final identity = OnlinePlaygroundIdentity(
       appID: appID,
       token: token,
-      enableDittoCloudSync: false,
     );
 
-    final documentsDir = await getApplicationDocumentsDirectory();
-    final persistenceDirectory = Directory("${documentsDir.path}/ditto");
-    await persistenceDirectory.create();
-
-    final ditto = await Ditto.open(
-      identity: identity,
-      persistenceDirectory: persistenceDirectory.path,
-    );
+    final ditto = await Ditto.open(identity: identity);
 
     ditto.updateTransportConfig((config) {
-      if (!kIsWeb) {
-        config.setAllPeerToPeerEnabled(true);
-      }
-      config.connect.webSocketUrls.add(
-        "wss://$appID.cloud.ditto.live",
-      );
+      // Note: this will not enable peer-to-peer sync on the web platform
+      config.setAllPeerToPeerEnabled(true);
     });
 
     ditto.startSync();
@@ -177,11 +161,9 @@ class _DittoExampleState extends State<DittoExample> {
         },
       );
 
-
   Widget _singleTask(Task task) => Dismissible(
         key: Key("${task.id}-${task.title}"),
         onDismissed: (direction) async {
-
           // Use the Soft-Delete pattern
           // https://docs.ditto.live/sdk/latest/crud/delete#soft-delete-pattern
           await _ditto!.store.execute(

--- a/flutter_app/pubspec.lock
+++ b/flutter_app/pubspec.lock
@@ -69,10 +69,10 @@ packages:
     dependency: "direct main"
     description:
       name: ditto_live
-      sha256: e4ce0600cb4a5d3bd5fde46c686421ab607fc04975b61205c656eca6aa30769c
+      sha256: a5b2d970aa2f7ab763b97b336a3d4fcac8869c83956cb3af3e648ba7700ba458
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.0"
+    version: "4.9.1"
   equatable:
     dependency: "direct main"
     description:

--- a/flutter_app/pubspec.lock
+++ b/flutter_app/pubspec.lock
@@ -217,7 +217,7 @@ packages:
     source: hosted
     version: "1.9.0"
   path_provider:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  ditto_live: ^4.9.0
+  ditto_live: ^4.9.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  ditto_live: ^4.9.1
+  ditto_live: 4.9.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -40,7 +40,6 @@ dependencies:
   equatable: ^2.0.5
   permission_handler: ^11.3.1
   json_annotation: ^4.9.0
-  path_provider: ^2.1.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Now that 4.9.1 is out, we use some of the new API changes to cut down on boilerplate a bit (and crucially allows the app to compile wth the upcoming web preview without code changes)