### PR TITLE
🥅 [kotlin-android] Use specific exceptions/errors in catch blocks

### DIFF
--- a/android-kotlin/QuickStartTasks/app/src/main/java/live/ditto/quickstart/tasks/data/Task.kt
+++ b/android-kotlin/QuickStartTasks/app/src/main/java/live/ditto/quickstart/tasks/data/Task.kt
@@ -1,6 +1,7 @@
 package live.ditto.quickstart.tasks.data
 
 import android.util.Log
+import org.json.JSONException
 import org.json.JSONObject
 import java.util.UUID
 
@@ -22,7 +23,7 @@ data class Task(
                     done = json["done"] as Boolean,
                     deleted = json["deleted"] as Boolean
                 )
-            } catch (e: Exception) {
+            } catch (e: JSONException) {
                 Log.e(TAG, "Unable to convert JSON to Task", e)
                 Task(title = "", done = false, deleted = false)
             }

--- a/android-kotlin/QuickStartTasks/app/src/main/java/live/ditto/quickstart/tasks/edit/EditScreenViewModel.kt
+++ b/android-kotlin/QuickStartTasks/app/src/main/java/live/ditto/quickstart/tasks/edit/EditScreenViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
+import live.ditto.DittoError
 import live.ditto.quickstart.tasks.DittoHandler.Companion.ditto
 import live.ditto.quickstart.tasks.data.Task
 
@@ -35,7 +36,7 @@ class EditScreenViewModel : ViewModel() {
                 _id = task._id
                 title.postValue(task.title)
                 done.postValue(task.done)
-            } catch (e: Exception) {
+            } catch (e: DittoError) {
                 Log.e(TAG, "Unable to setup view task data", e)
             }
         }
@@ -78,7 +79,7 @@ class EditScreenViewModel : ViewModel() {
                         )
                     }
                 }
-            } catch (e: Exception) {
+            } catch (e: DittoError) {
                 Log.e(TAG, "Unable to save task", e)
             }
         }
@@ -95,7 +96,7 @@ class EditScreenViewModel : ViewModel() {
                         mapOf("id" to id)
                     )
                 }
-            } catch (e: Exception) {
+            } catch (e: DittoError) {
                 Log.e(TAG, "Unable to set deleted=true", e)
             }
         }

--- a/android-kotlin/QuickStartTasks/app/src/main/java/live/ditto/quickstart/tasks/list/TasksListScreenViewModel.kt
+++ b/android-kotlin/QuickStartTasks/app/src/main/java/live/ditto/quickstart/tasks/list/TasksListScreenViewModel.kt
@@ -112,7 +112,7 @@ class TasksListScreenViewModel : ViewModel() {
                             )
                         )
                     )
-                } catch (e: Exception) {
+                } catch (e: DittoError) {
                     Log.e(TAG, "Unable to insert initial document", e)
                 }
             }
@@ -138,7 +138,7 @@ class TasksListScreenViewModel : ViewModel() {
                         "_id" to taskId
                     )
                 )
-            } catch (e: Exception) {
+            } catch (e: DittoError) {
                 Log.e(TAG, "Unable to toggle done state", e)
             }
         }
@@ -153,7 +153,7 @@ class TasksListScreenViewModel : ViewModel() {
                     "UPDATE tasks SET deleted = true WHERE _id = :id",
                     mapOf("id" to taskId)
                 )
-            } catch (e: Exception) {
+            } catch (e: DittoError) {
                 Log.e(TAG, "Unable to set deleted=true", e)
             }
         }


### PR DESCRIPTION
## Problem

An issue arose in the `android-kotlin` quickstart where upcoming DQL syntax was causing the app to crash. This behavior differed from the `swift` and `android-java` apps which simply logged an error message about the invalid query.

```
FATAL EXCEPTION: main
	Process: live.ditto.quickstart.tasks, PID: 20816
	StoreError(reason=QueryInvalid(message=<dql> Invalid query: `A projection other than wildcard (*) is not supported`. For more information on Ditto's query language see: https://docs.ditto.live/dql-guide))
		at live.ditto.DittoError$Companion.fromFfi$ditto_release(DittoError.kt:118)
		at live.ditto.DqlResponseResult$Companion.fromNative-IoAF18A(DqlResponseResult.kt:18)
		at live.ditto.DittoStore.execute(DittoStore.kt:98)
		at live.ditto.DittoStore.execute$default(DittoStore.kt:79)...
```

## Solution

These crashes were due to the fact that the Kotlin `catch` blocks were attempting to catch `Exception`. However, `ditto.store.execute()` throws `DittoError` in this case. `DittoError` is an extension of `Throwable`, the parent type for `Exception`.

This PR aligns the `android-kotlin` error handling with the other apps.