### PR TITLE
android-java: fix description of where Ditto SDK version is set

### DIFF
--- a/android-java/README.md
+++ b/android-java/README.md
@@ -50,11 +50,18 @@ summary of the key parts of integration with Ditto.
 
 ### Adding the Ditto SDK
 
-At the bottom of `app/build.gradle.kts`, you will see this line that causes
-Android Studio to automatically download the Ditto SDK from Maven Central and
-add it to the project:
+In `gradle/build.gradle.kts`, you will see this line that causes Android Studio
+to download the Ditto SDK from Maven Central and add it to the project:
 
-```implementation("live.ditto:ditto:4.10.0")
+```kotlin
+    implementation(libs.ditto)
 ```
 
-To use a newer version of the SDK, change the version number in this line.
+This line in `gradle/libs.versions.toml` specifies which version of the Ditto
+SDK to use:
+
+```kotlin
+ditto = "4.10.0"
+```
+
+To use a newer version of the SDK, change the version number on this line.

--- a/android-java/gradle/libs.versions.toml
+++ b/android-java/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
+ditto = "4.10.0"
 agp = "8.7.3"
 constraintlayout = "2.2.0"
-ditto = "4.10.0"
 kotlin = "2.0.0"
 coreKtx = "1.10.1"
 junit = "4.13.2"
@@ -39,4 +39,3 @@ recyclerview-v7 = { module = "com.android.support:recyclerview-v7", version.ref 
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-


### PR DESCRIPTION
In `android-java/README.md`, fix description of where Ditto SDK version is set.

(It looks like the original text was copied and pasted from the README for `android-kotlin` or `android-cpp`.