### PR TITLE
fix(rn): remove hardcoded Ditto Java dependency

### DIFF
--- a/react-native/android/app/build.gradle
+++ b/react-native/android/app/build.gradle
@@ -124,8 +124,6 @@ dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 
-    implementation "live.ditto:ditto:4.8.1"
-
     if (hermesEnabled.toBoolean()) {
         implementation("com.facebook.react:hermes-android")
     } else {


### PR DESCRIPTION
This slipped in and shouldn't be here. The RN SDK downloads the corresponding dependency automatically on build.