### PR TITLE
Fix Xcode project on case-sensitive file systems

### DIFF
--- a/swift/tasks/tasks.xcodeproj/project.pbxproj
+++ b/swift/tasks/tasks.xcodeproj/project.pbxproj
@@ -15,23 +15,10 @@
 		41F8698A2CECF42500DC7268 /* Ditto Tasks.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Ditto Tasks.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
-/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		4170A8592CED356700043F5A /* Exceptions for "Tasks" folder in "Ditto Tasks" target */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				Info.plist,
-			);
-			target = 41F869892CECF42500DC7268 /* Ditto Tasks */;
-		};
-/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
-
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		41F8698C2CECF42500DC7268 /* Tasks */ = {
+		41F8698C2CECF42500DC7268 /* tasks */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				4170A8592CED356700043F5A /* Exceptions for "Tasks" folder in "Ditto Tasks" target */,
-			);
-			path = Tasks;
+			path = tasks;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -52,7 +39,7 @@
 		41F869812CECF42500DC7268 = {
 			isa = PBXGroup;
 			children = (
-				41F8698C2CECF42500DC7268 /* Tasks */,
+				41F8698C2CECF42500DC7268 /* tasks */,
 				41F8698B2CECF42500DC7268 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -82,7 +69,7 @@
 			dependencies = (
 			);
 			fileSystemSynchronizedGroups = (
-				41F8698C2CECF42500DC7268 /* Tasks */,
+				41F8698C2CECF42500DC7268 /* tasks */,
 			);
 			name = "Ditto Tasks";
 			packageProductDependencies = (


### PR DESCRIPTION
The Xcode project is broken on case-sensitive file systems due to the first letter of the `Tasks` group being uppercase, while the folder on the file system is lowercase.

I'll submit a second PR in a bit turning all of those into upper case (usually a bit of a dance with git in this case, therefore separate PR).

![Screenshot 2025-05-27 at 09 16 37](https://github.com/user-attachments/assets/8ca974de-e057-438f-be6e-478402402e9c)

![Screenshot 2025-05-27 at 09 17 11](https://github.com/user-attachments/assets/097a5b7b-53fe-448e-968c-940ce759b50d)

