### PR TITLE
Remove unneeded code

### DIFF
--- a/react-native/App.tsx
+++ b/react-native/App.tsx
@@ -133,10 +133,6 @@ const App = () => {
       ditto.current.updateTransportConfig(config => {
         config.connect.websocketURLs = [DITTO_WEBSOCKET_URL];
 
-        if (Platform.OS === 'android') {
-          config.peerToPeer.awdl.isEnabled = false;
-        }
-
         return config;
       });
 


### PR DESCRIPTION
Platform-specific transports are already enabled/disabled in JS by default. Follow-up to #73 