### PR TITLE
refactor(kmp): disable default cloud sync 

### DIFF
--- a/kotlin-multiplatform/.gitignore
+++ b/kotlin-multiplatform/.gitignore
@@ -5,8 +5,8 @@
 .gradle
 .idea
 .kotlin
+/composeApp/ditto/
+/composeApp/tasks.preferences_pb
 build/
 captures
-ditto/
 local.properties
-tasks.preferences_pb

--- a/kotlin-multiplatform/composeApp/src/commonMain/kotlin/com/ditto/quickstart/ditto/DittoManager.kt
+++ b/kotlin-multiplatform/composeApp/src/commonMain/kotlin/com/ditto/quickstart/ditto/DittoManager.kt
@@ -45,7 +45,7 @@ class DittoManager {
                 val identity = DittoIdentity.OnlinePlayground(
                     appId = DittoSecretsConfiguration.DITTO_APP_ID,
                     token = DittoSecretsConfiguration.DITTO_PLAYGROUND_TOKEN,
-                    enableDittoCloudSync = true,
+                    enableDittoCloudSync = false,
                     customAuthUrl = DittoSecretsConfiguration.DITTO_AUTH_URL,
                 )
 


### PR DESCRIPTION
This PR disables the `enableDittoCloudSync` parameter when initializing the `DittoIdentity`. This is not wanted because the app has a websocket connection wired up explicitly in `DittoManager`.