### PR TITLE
SDKS-1260 Crash on Ditto 4.11.0 on Android API 27 (Oreo 8.1) - subsequent launches

### DIFF
--- a/android-kotlin/QuickStartTasks/app/build.gradle.kts
+++ b/android-kotlin/QuickStartTasks/app/build.gradle.kts
@@ -138,5 +138,6 @@ dependencies {
     debugImplementation(libs.androidx.ui.test.manifest)
 
     // Ditto SDK
-    implementation("live.ditto:ditto:4.10.0")
+    //implementation("live.ditto:ditto:4.10.0")
+    implementation("live.ditto:ditto:4.11.0")
 }

--- a/android-kotlin/QuickStartTasks/app/src/main/java/live/ditto/quickstart/tasks/TasksApplication.kt
+++ b/android-kotlin/QuickStartTasks/app/src/main/java/live/ditto/quickstart/tasks/TasksApplication.kt
@@ -56,6 +56,9 @@ class TasksApplication : Application() {
         ditto.updateTransportConfig { config ->
             // Set the Ditto Websocket URL
             config.connect.websocketUrls.add(webSocketURL)
+
+            // Temporary workaround to prevent crash
+            config.peerToPeer.wifiAware.enabled = false
         }
 
         // disable sync with v3 peers, required for DQL

--- a/android-kotlin/QuickStartTasks/app/src/main/java/live/ditto/quickstart/tasks/TasksApplication.kt
+++ b/android-kotlin/QuickStartTasks/app/src/main/java/live/ditto/quickstart/tasks/TasksApplication.kt
@@ -57,8 +57,10 @@ class TasksApplication : Application() {
             // Set the Ditto Websocket URL
             config.connect.websocketUrls.add(webSocketURL)
 
-            // Temporary workaround to prevent crash
-            config.peerToPeer.wifiAware.enabled = false
+            if (Build.VERSION.SDK_INT <= 27) {
+                // Temporary workaround to prevent crash on Android 8.1 and below
+                config.peerToPeer.wifiAware.enabled = false
+            }
         }
 
         // disable sync with v3 peers, required for DQL


### PR DESCRIPTION
Branch for reproduction and investigation of https://linear.app/ditto/issue/SDKS-1260/crash-on-ditto-4110-on-android-api-27-oreo-81-subsequent-launches

1. Update SDK version to 4.11.0
   * This reproduces the crash on API 27
2. Disable wifiAware in transport config for API 27 and earlier
   * This prevents the crash