### PR TITLE
Fix maui windows

### DIFF
--- a/dotnet-maui/DittoMauiTasksApp/DittoMauiTasksApp.sln
+++ b/dotnet-maui/DittoMauiTasksApp/DittoMauiTasksApp.sln
@@ -6,20 +6,22 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DittoMauiTasksApp", "DittoMauiTasksApp.csproj", "{01D3B2D3-C50F-4C2A-9B8E-8C4CA20CA850}"
 EndProject
 Global
-    GlobalSection(SolutionConfigurationPlatforms) = preSolution
-        Debug|Any CPU = Debug|Any CPU
-        Release|Any CPU = Release|Any CPU
-    EndGlobalSection
-    GlobalSection(ProjectConfigurationPlatforms) = postSolution
-        {01D3B2D3-C50F-4C2A-9B8E-8C4CA20CA850}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-        {01D3B2D3-C50F-4C2A-9B8E-8C4CA20CA850}.Debug|Any CPU.Build.0 = Debug|Any CPU
-        {01D3B2D3-C50F-4C2A-9B8E-8C4CA20CA850}.Release|Any CPU.ActiveCfg = Release|Any CPU
-        {01D3B2D3-C50F-4C2A-9B8E-8C4CA20CA850}.Release|Any CPU.Build.0 = Release|Any CPU
-    EndGlobalSection
-    GlobalSection(SolutionProperties) = preSolution
-        HideSolutionNode = FALSE
-    EndGlobalSection
-    GlobalSection(ExtensibilityGlobals) = postSolution
-        SolutionGuid = {6FB99CB4-FC14-42E1-8C56-D40967D0CF75}
-    EndGlobalSection
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{01D3B2D3-C50F-4C2A-9B8E-8C4CA20CA850}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{01D3B2D3-C50F-4C2A-9B8E-8C4CA20CA850}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{01D3B2D3-C50F-4C2A-9B8E-8C4CA20CA850}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{01D3B2D3-C50F-4C2A-9B8E-8C4CA20CA850}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{01D3B2D3-C50F-4C2A-9B8E-8C4CA20CA850}.Release|Any CPU.Build.0 = Release|Any CPU
+		{01D3B2D3-C50F-4C2A-9B8E-8C4CA20CA850}.Release|Any CPU.Deploy.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		        SolutionGuid = {6FB99CB4-FC14-42E1-8C56-D40967D0CF75}
+	EndGlobalSection
 EndGlobal

--- a/dotnet-maui/DittoMauiTasksApp/ViewModels/TasksPageviewModel.cs
+++ b/dotnet-maui/DittoMauiTasksApp/ViewModels/TasksPageviewModel.cs
@@ -33,22 +33,38 @@ namespace DittoMauiTasksApp.ViewModels
             this.ditto = ditto;
             this.popupService = popupService;
             this.logger = logger;
-
-            DittoSyncPermissions.RequestPermissionsAsync().ContinueWith(async t =>
-            {
+#if WINDOWS
                 try
                 {
-                    await InsertInitialTasks();
-                    ObserveDittoTasksCollection();
-                    StartSync();
+                    Task.Run(async () =>
+                    {
+                        await InsertInitialTasks();
+                        ObserveDittoTasksCollection();
+                        StartSync();
+
+                    });
                 }
                 catch (Exception e)
                 {
                     logger.LogError($"TasksPageviewModel: Unable to start Ditto sync: {e.Message}");
                 }
-            });
-        }
+#else
 
+                DittoSyncPermissions.RequestPermissionsAsync().ContinueWith(async t =>
+                {
+                    try
+                    {
+                        await InsertInitialTasks();
+                        ObserveDittoTasksCollection();
+                        StartSync();
+                    }
+                    catch (Exception e)
+                    {
+                        logger.LogError($"TasksPageviewModel: Unable to start Ditto sync: {e.Message}");
+                    }
+                });
+#endif
+            }
         private async Task InsertInitialTasks()
         {
             try

--- a/dotnet-maui/README.md
+++ b/dotnet-maui/README.md
@@ -14,14 +14,18 @@
 
 - [Ditto C# .NET SDK Install Guide](https://docs.ditto.live/install-guides/c-sharp)
 - [Ditto C# .NET SDK API Reference](https://software.ditto.live/dotnet/Ditto/4.9.1/api-reference/)
+### Restore Packages
 
+```sh
+cd DittoMauiTasksApp
+dotnet restore
+```
 
 ### Building and Running the App on iOS
 
 These commands will build and run the app on the default iOS target:
 
-```
-cd DittoMauiTasksApp
+```sh
 dotnet build -t:Run -f net9.0-ios
 ```
 
@@ -29,13 +33,25 @@ dotnet build -t:Run -f net9.0-ios
 
 These commands will build and run the app on the default Android target:
 
-```
-cd DittoMauiTasksApp
+```sh
 dotnet build -t:Run -f net9.0-android
+```
+
+### Building and Running the App on MacOS 
+
+```sh
+dotnet build -t:Run -f net9.0-maccatalyst 
+```
+
+### Building and Running the App on Windows 
+
+```sh
+dotnet build -t:Run -f net9.0-windows10.0.19041.0 
 ```
 
 ### Other MAUI Platforms
 
-Building the MAUI app for platforms other than iOS and Android is not supported
-by Ditto at this time.
+Other platforms not supported at this time. 
+
+
 


### PR DESCRIPTION
This is a quick fix to make the Windows platform work by adding in code to detect if it's Windows and to not run code to ask for permissions on BLE and WIFI.  This also updates the readme file to explain how to compile from the command line.  Visual Studio users won't need this.

Code was tested on Windows 11 with latest .NET 9 and Maui release and known to be working.