### PR TITLE
ISSUE While authenticating with Online Playground Identity

### DIFF
--- a/android-kotlin/QuickStartTasks/app/src/main/java/live/ditto/quickstart/tasks/TasksApplication.kt
+++ b/android-kotlin/QuickStartTasks/app/src/main/java/live/ditto/quickstart/tasks/TasksApplication.kt
@@ -30,6 +30,8 @@ class TasksApplication : Application() {
     }
 
     private fun setupDitto() {
+        DittoLogger.minimumLogLevel = DittoLogLevel.DEBUG
+
         val androidDependencies = DefaultAndroidDittoDependencies(applicationContext)
 
         //read values from build.gradle.kts (Module:app) which reads from environment file


### PR DESCRIPTION
I noticed the following warnings on the logcat while using the Online Playground.
```
W  auth_client_x509_refresh: no valid JWT (received upon successful login to auth server) present, cannot request X.509 certificate before that exists
W  auth_client_x509_refresh: failed to refresh X.509 certificate, retrying in 60 seconds e=Config value missing
W  anonymous_login_provider_refresh: error connecting to auth server when requesting a login challenge e=error sending request for url (https://c5adf242-f3fc-4987-aac9-3cb79967274e.cloud.ditto.live/_ditto/auth/challenge)
```

The complete logs are attached for reference.
[quickstart-app-logs.txt](https://github.com/user-attachments/files/21370260/quickstart-app-logs.txt)
