### PR TITLE
feat(android-cpp): build Android C++ Tasks app with 4.12.0-preview.1

### DIFF
--- a/android-cpp/QuickStartTasksCPP/app/build.gradle.kts
+++ b/android-cpp/QuickStartTasksCPP/app/build.gradle.kts
@@ -135,7 +135,7 @@ android {
 
 dependencies {
     // Ditto C++ SDK for Android
-    implementation("live.ditto:ditto-cpp:4.11.0")
+    implementation("live.ditto:ditto-cpp:4.12.0-preview.1")
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)


### PR DESCRIPTION
Updates the dependency to 4.12.0-preview.1 for the Android C++ Tasks app.

I verified that I can build, install, and run this on two Android devices, and syncing works as expected.

Keeping this PR in draft state for now. When the production 4.12.0 release is published, we can update this app.