### PR TITLE
Update: updated package to v4.11.1 and updated API calls to v2

### DIFF
--- a/rust-tui/Cargo.lock
+++ b/rust-tui/Cargo.lock
@@ -448,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "dittolive-ditto"
-version = "4.10.0"
+version = "4.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e6133ccc415b94298d9d7d889a0f7ee91b70e249dfff24df2a99e704ca3c9c2"
+checksum = "42f866664709eb6f886b1ad16304dbc9ca1c88e1879d06ba973fedc1465055e7"
 dependencies = [
  "base64",
  "bytemuck",
@@ -482,9 +482,9 @@ dependencies = [
 
 [[package]]
 name = "dittolive-ditto-sys"
-version = "4.10.0"
+version = "4.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842bca58e74c22f03b326f129c27d99e29b7e48b8b6152da45b328ce22cda549"
+checksum = "963d1b0872da4863700bd6cbdda44c30963765600960b2000331e833a905f3d1"
 dependencies = [
  "macro_rules_attribute",
  "paste",

--- a/rust-tui/Cargo.toml
+++ b/rust-tui/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/bin/main.rs"
 
 [dependencies]
 # Ditto dependenceis
-dittolive-ditto = "4.10.0"
+dittolive-ditto = "4.11.1"
 
 # External dependencies
 anyhow = "1"

--- a/rust-tui/src/bin/main.rs
+++ b/rust-tui/src/bin/main.rs
@@ -56,7 +56,7 @@ async fn main() -> Result<()> {
         cli.app_id, 
         cli.token, 
         cli.custom_auth_url, 
-        cli.websocket_url)?;
+        cli.websocket_url).await?;
     let _tui_task = TuiTask::try_spawn(shutdown.clone(), terminal, ditto)
         .context("failed to start tui task")?;
     tracing::info!(success = true, "Initialized!");
@@ -88,11 +88,12 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-fn try_init_ditto(
+async fn try_init_ditto(
     app_id: AppId, 
     token: String, 
     custom_auth_url: String, 
     websocket_url: String) -> Result<Ditto> {
+    println!("Building Ditto instance...");
     // We use a temporary directory to store Ditto's local database.  
     // This means that data will not be persistent between runs of the
     // application, but it allows us to run multiple instances of the
@@ -119,6 +120,10 @@ fn try_init_ditto(
 
     // disable sync with v3 peers, required for DQL
     _ = ditto.disable_sync_with_v3();
+
+    // disable DQL strict mode
+    // https://docs.ditto.live/dql/strict-mode
+    _ = ditto.store().execute_v2("ALTER SYSTEM SET DQL_STRICT_MODE = false").await?;
 
     // Start sync
     _ = ditto.start_sync();

--- a/rust-tui/src/bin/main.rs
+++ b/rust-tui/src/bin/main.rs
@@ -93,7 +93,6 @@ async fn try_init_ditto(
     token: String, 
     custom_auth_url: String, 
     websocket_url: String) -> Result<Ditto> {
-    println!("Building Ditto instance...");
     // We use a temporary directory to store Ditto's local database.  
     // This means that data will not be persistent between runs of the
     // application, but it allows us to run multiple instances of the

--- a/rust-tui/src/tui/todolist.rs
+++ b/rust-tui/src/tui/todolist.rs
@@ -320,10 +320,10 @@ impl Todolist {
             .store()
             .execute_v2((
                 "UPDATE tasks SET done=:done WHERE _id=:id",
-                Some(serde_json::json!({
+                serde_json::json!({
                     "id": id,
                     "done": !done,
-                })),
+                }),
             ))
             .await?;
 

--- a/rust-tui/src/tui/todolist.rs
+++ b/rust-tui/src/tui/todolist.rs
@@ -347,9 +347,9 @@ impl Todolist {
             .store()
             .execute_v2((
                 "UPDATE tasks SET deleted=true WHERE _id=:id",
-                Some(serde_json::json!({
+                serde_json::json!({
                     "id": id
-                }))),
+                })),
             )
             .await?;
 
@@ -363,9 +363,9 @@ impl Todolist {
             .store()
             .execute_v2((
                 "INSERT INTO tasks DOCUMENTS (:task)",
-                Some(serde_json::json!({
+                serde_json::json!({
                     "task": task
-                }))),
+                })),
             )
             .await?;
         Ok(())
@@ -377,10 +377,10 @@ impl Todolist {
             .store()
             .execute_v2((
                 "UPDATE tasks SET title=:title WHERE _id=:id",
-                Some(serde_json::json!({ 
+                serde_json::json!({ 
                     "title": title, 
                     "id": id 
-                }))),
+                })),
             )
             .await?;
 

--- a/rust-tui/src/tui/todolist.rs
+++ b/rust-tui/src/tui/todolist.rs
@@ -89,14 +89,13 @@ impl Todolist {
         // https://docs.ditto.live/sdk/latest/sync/syncing-data#creating-subscriptions
         let tasks_subscription = ditto
             .sync()
-            .register_subscription("SELECT * FROM tasks", None)?;
+            .register_subscription_v2("SELECT * FROM tasks")?;
         let tasks_subscription = Some(tasks_subscription);
 
         // register observer for live query
         // Register observer, which runs against the local database on this peer
-        let tasks_observer = ditto.store().register_observer(
+        let tasks_observer = ditto.store().register_observer_v2(
             "SELECT * FROM tasks WHERE deleted=false ORDER BY _id",
-            None,
             move |query_result| {
                 let docs = query_result
                     .into_iter()
@@ -296,7 +295,7 @@ impl Todolist {
                 let sub = self
                     .ditto
                     .sync()
-                    .register_subscription("SELECT * FROM tasks", None)?;
+                    .register_subscription_v2("SELECT * FROM tasks")?;
                 Some(sub)
             }
         };
@@ -319,16 +318,13 @@ impl Todolist {
         let done = selected_task.done;
         self.ditto
             .store()
-            .execute(
+            .execute_v2((
                 "UPDATE tasks SET done=:done WHERE _id=:id",
-                Some(
-                    serde_json::json!({
-                        "id": id,
-                        "done": !done,
-                    })
-                    .into(),
-                ),
-            )
+                Some(serde_json::json!({
+                    "id": id,
+                    "done": !done,
+                })),
+            ))
             .await?;
 
         Ok(())
@@ -349,9 +345,11 @@ impl Todolist {
         let id = selected_task.id;
         self.ditto
             .store()
-            .execute(
+            .execute_v2((
                 "UPDATE tasks SET deleted=true WHERE _id=:id",
-                Some(serde_json::json!({"id": id}).into()),
+                Some(serde_json::json!({
+                    "id": id
+                }))),
             )
             .await?;
 
@@ -363,9 +361,11 @@ impl Todolist {
         let task = TodoItem::new(title);
         self.ditto
             .store()
-            .execute(
+            .execute_v2((
                 "INSERT INTO tasks DOCUMENTS (:task)",
-                Some(serde_json::json!({"task": task}).into()),
+                Some(serde_json::json!({
+                    "task": task
+                }))),
             )
             .await?;
         Ok(())
@@ -375,9 +375,12 @@ impl Todolist {
     pub async fn try_edit_todo(&mut self, id: &str, title: &str) -> Result<()> {
         self.ditto
             .store()
-            .execute(
+            .execute_v2((
                 "UPDATE tasks SET title=:title WHERE _id=:id",
-                Some(serde_json::json!({ "title": title, "id": id }).into()),
+                Some(serde_json::json!({ 
+                    "title": title, 
+                    "id": id 
+                }))),
             )
             .await?;
 


### PR DESCRIPTION
## 📌 Linear Ticket

Please include a link to the corresponding Linear issue:

https://linear.app/ditto/issue/MAR-161/update-quickstarts-to-4111-and-set-dql-strict-mode-=-false

> Example: https://linear.app/ditto/issue/ABC-1234/short-description-here
---

## 📝 Description of the Change

- Updates the Ditto SDK to 4.11.1
- Sets Strict Mode to equal false
- Updates calling Ditto API calls to use the new v2 version of the calls.

> Provide a concise summary of what this PR does.
> Include context, reasoning behind the change, and any relevant implementation details.

---

## 🧪 Local Testing Summary

Please indicate which platforms this change was tested on:

- [x] Windows
- [x] macOS
- [x] Linux x86
- [ ] Linux ARM

> ✅ Reminder: You are responsible for testing this change on all platforms the application supports.  
> If you are unable to test on a platform, please coordinate with another team member or request assistance.

---

## 📷 Screenshots (if applicable)
> Add screenshots or demo gifs/videos if this PR includes UI changes or notable behavior differences.

No UI changes made.
