### PR TITLE
Android CPP:  Updated the readme file along with the SDK to 4.11 and disabled strict mode

### DIFF
--- a/android-cpp/QuickStartTasksCPP/app/build.gradle.kts
+++ b/android-cpp/QuickStartTasksCPP/app/build.gradle.kts
@@ -33,7 +33,7 @@ androidComponents {
             "DITTO_APP_ID",
             BuildConfigField(
                 "String",
-                "${prop["DITTO_APP_ID"]}",
+                "\"${prop["DITTO_APP_ID"]}\"",
                 "Ditto application ID"
             )
         )
@@ -41,7 +41,7 @@ androidComponents {
             "DITTO_PLAYGROUND_TOKEN",
             BuildConfigField(
                 "String",
-                "${prop["DITTO_PLAYGROUND_TOKEN"]}",
+                "\"${prop["DITTO_PLAYGROUND_TOKEN"]}\"",
                 "Ditto online playground authentication token"
             )
         )
@@ -49,7 +49,7 @@ androidComponents {
             "DITTO_AUTH_URL",
             BuildConfigField(
                 "String",
-                "${prop["DITTO_AUTH_URL"]}",
+                "\"${prop["DITTO_AUTH_URL"]}\"",
                 "Ditto Auth URL"
             )
         )
@@ -58,7 +58,7 @@ androidComponents {
             "DITTO_WEBSOCKET_URL",
             BuildConfigField(
                 "String",
-                "${prop["DITTO_WEBSOCKET_URL"]}",
+                "\"${prop["DITTO_WEBSOCKET_URL"]}\"",
                 "Ditto Websocket URL"
             )
         )
@@ -100,11 +100,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
     buildFeatures {
         buildConfig = true
@@ -135,7 +135,7 @@ android {
 
 dependencies {
     // Ditto C++ SDK for Android
-    implementation("live.ditto:ditto-cpp:4.11.0")
+    implementation("live.ditto:ditto-cpp:4.11.1")
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/android-cpp/QuickStartTasksCPP/app/src/main/cpp/tasks_peer.cpp
+++ b/android-cpp/QuickStartTasksCPP/app/src/main/cpp/tasks_peer.cpp
@@ -76,8 +76,7 @@ unique_ptr<ditto::Ditto> init_ditto(JNIEnv *env,
 
     // Disable DQL strict mode
     // https://docs.ditto.live/dql/strict-mode
-    const auto disableStrictModeCommand = "ALTER SYSTEM SET DQL_STRICT_MODE = false";
-    const auto result = ditto->get_store().execute(disableStrictModeCommand);
+    const auto result = ditto->get_store().execute("ALTER SYSTEM SET DQL_STRICT_MODE = false");
 
     return ditto;
   } catch (const exception &err) {

--- a/android-cpp/QuickStartTasksCPP/app/src/main/cpp/tasks_peer.cpp
+++ b/android-cpp/QuickStartTasksCPP/app/src/main/cpp/tasks_peer.cpp
@@ -74,6 +74,11 @@ unique_ptr<ditto::Ditto> init_ditto(JNIEnv *env,
     // Required for compatibility with DQL.
     ditto->disable_sync_with_v3();
 
+    // Disable DQL strict mode
+    // https://docs.ditto.live/dql/strict-mode
+    const auto disableStrictModeCommand = "ALTER SYSTEM SET DQL_STRICT_MODE = false";
+    const auto result = ditto->get_store().execute(disableStrictModeCommand);
+
     return ditto;
   } catch (const exception &err) {
     throw runtime_error(string("unable to initialize Ditto: ") + err.what());

--- a/android-cpp/QuickStartTasksCPP/gradle/libs.versions.toml
+++ b/android-cpp/QuickStartTasksCPP/gradle/libs.versions.toml
@@ -1,17 +1,17 @@
 [versions]
 agp = "8.7.3"
 kotlin = "1.9.24"
-coreKtx = "1.15.0"
+coreKtx = "1.16.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
-lifecycleRuntimeKtx = "2.8.7"
-activityCompose = "1.9.3"
-composeBom = "2024.10.01"
-navigationCompose = "2.8.3"
-runtimeLivedata = "1.7.5"
-appcompat = "1.7.0"
-datastorePreferences = "1.1.1"
+lifecycleRuntimeKtx = "2.9.2"
+activityCompose = "1.10.1"
+composeBom = "2025.07.00"
+navigationCompose = "2.9.2"
+runtimeLivedata = "1.8.3"
+appcompat = "1.7.1"
+datastorePreferences = "1.1.7"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }

--- a/android-cpp/README.md
+++ b/android-cpp/README.md
@@ -13,7 +13,7 @@ After you have completed the [common prerequisites] you will need the following:
 ## Documentation
 
 - [C++ Install Guide](https://docs.ditto.live/install-guides/cpp)
-- [C++ API Reference](https://software.ditto.live/cpp/Ditto/4.9.0/api-reference/)
+- [C++ API Reference](https://software.ditto.live/cpp/Ditto/4.11.0/api-reference/)
 - [C++ Release Notes](https://docs.ditto.live/release-notes/cpp)
 
 [common prerequisites]: https://github.com/getditto/quickstart#common-prerequisites


### PR DESCRIPTION
## 📌 Linear Ticket

Please include a link to the corresponding Linear issue:

https://linear.app/ditto/issue/MAR-161/update-quickstarts-to-4111-and-set-dql-strict-mode-=-false

> Example: https://linear.app/ditto/issue/ABC-1234/short-description-here
---

## 📝 Description of the Change

- Updates the Ditto SDK to 4.11.1
- Sets Strict Mode to equal false
- Updated the README file with links to the proper SDK version

> Provide a concise summary of what this PR does.
> Include context, reasoning behind the change, and any relevant implementation details.

---

## 🧪 Local Testing Summary

Please indicate which platforms this change was tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux x86
- [ ] Linux ARM

Please indicate if you tested on emulator, simulator, or physical mobile devices:
- [x] Emulator
- [ ] Simulator
- [x] Physical Device

> ✅ Reminder: You are responsible for testing this change on all platforms the application supports.  
> If you are unable to test on a platform, please coordinate with another team member or request assistance.

---

## 📷 Screenshots (if applicable)
> Add screenshots or demo gifs/videos if this PR includes UI changes or notable behavior differences.

No UI changes made.
