### PR TITLE
CPP Tui:  Updated SDK to 4.11, set strict mode to false, and updated README

### DIFF
--- a/cpp-tui/README.md
+++ b/cpp-tui/README.md
@@ -16,7 +16,7 @@ subdirectory of this project.
 ## Documentation
 
 - [C++ Install Guide](https://docs.ditto.live/install-guides/cpp)
-- [C++ API Reference](https://software.ditto.live/cpp/Ditto/4.9.0/api-reference/)
+- [C++ API Reference](https://software.ditto.live/cpp/Ditto/4.11.0/api-reference/)
 - [C++ Release Notes](https://docs.ditto.live/release-notes/cpp)
 
 [common prerequisites]: https://github.com/getditto/quickstart#common-prerequisites
@@ -27,14 +27,14 @@ Assuming you have the prerequisites installed, you can build and run the app by 
 
 1. Create an application at <https://portal.ditto.live/>.  Make note of the app ID and online playground token.
 2. Copy the `.env.sample` file at the top level of the `quickstart` repo to `.env` and add your app ID and online playground token.
-3. In a shell, navigate to the `quickstart/cpp/taskscpp` directory and run the command `make build` to build the C++ application.
+3. In a shell, navigate to the `quickstart/cpp-tui/taskscpp` directory and run the command `make build` to build the C++ application.
 
 ## Running the Application
 
 The application is named `taskscpp` and is located in the `quickstart/cpp/taskscpp/build` directory.
 
 You can run the application and see the available command-line options from the
-`quickstart/cpp/taskscpp` directory by running this command:
+`quickstart/cpp-tui/taskscpp` directory by running this command:
 
 ```sh
 ./build/taskscpp --help

--- a/cpp-tui/taskscpp/src/tasks_peer.cpp
+++ b/cpp-tui/taskscpp/src/tasks_peer.cpp
@@ -69,6 +69,12 @@ static shared_ptr<ditto::Ditto> init_ditto(string app_id,
     // Required for compatibility with DQL.
     ditto->disable_sync_with_v3();
 
+     
+    // Disable DQL strict mode
+    // https://docs.ditto.live/dql/strict-mode
+    const auto disableStrictModeCommand = "ALTER SYSTEM SET DQL_STRICT_MODE = false";
+    const auto result = ditto->get_store().execute(disableStrictModeCommand);
+
     return ditto;
   } catch (const exception &err) {
     throw runtime_error("unable to initialize Ditto: " + string(err.what()));


### PR DESCRIPTION
## 📌 Linear Ticket

Please include a link to the corresponding Linear issue:

https://linear.app/ditto/issue/MAR-161/update-quickstarts-to-4111-and-set-dql-strict-mode-=-false

> Example: https://linear.app/ditto/issue/ABC-1234/short-description-here
---

## 📝 Description of the Change

- Updates the Ditto SDK to 4.11.1
- Sets Strict Mode to equal false
- Updated the README file with links to the proper SDK version

> Provide a concise summary of what this PR does.
> Include context, reasoning behind the change, and any relevant implementation details.

---

## 🧪 Local Testing Summary

Please indicate which platforms this change was tested on:

- [ ] Windows
- [ ] macOS
- [x] Linux x86
- [ ] Linux ARM

Please indicate if you tested on emulator, simulator, or physical mobile devices:
- [ ] Emulator
- [ ] Simulator
- [ ] Virtual Machine
- [x] Physical Device

> ✅ Reminder: You are responsible for testing this change on all platforms the application supports.  
> If you are unable to test on a platform, please coordinate with another team member or request assistance.

---

## 📷 Screenshots (if applicable)
> Add screenshots or demo gifs/videos if this PR includes UI changes or notable behavior differences.

No UI changes made.
