### PR TITLE
Javascript Tui - Updated SDK to 4.11.1, set strict mode to false, and updated README

### DIFF
--- a/javascript-tui/README.md
+++ b/javascript-tui/README.md
@@ -26,9 +26,16 @@ DITTO_WEBSOCKET_URL=""
 
 Next, make sure you have `npm` installed, then run the following:
 
-```
+**MacOS/Linux**
+```bash
 npm install
 npm start 2>/dev/null
+```
+
+**Windows**
+```bash
+npm install
+npm start 2>NUL
 ```
 
 > NOTE: the `2>/dev/null` silences log output on stderr, because the logs

--- a/javascript-tui/package-lock.json
+++ b/javascript-tui/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"@dittolive/ditto": "^4.10.0",
+				"@dittolive/ditto": "^4.11.1",
 				"dotenv": "^16.4.5",
 				"ink": "^4.1.0",
 				"meow": "^11.0.0",
@@ -2425,10 +2425,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@dittolive/ditto": {
-			"version": "4.10.2",
-			"resolved": "https://registry.npmjs.org/@dittolive/ditto/-/ditto-4.10.2.tgz",
-			"integrity": "sha512-cZTw+xrgE18ps77UKXC8tYDlghf4JzNoDGqtPFqVNoUzi5VA3aPfYwFq62VlSRJxVQUPhEEvDV/sE56h5tw4KQ==",
-			"license": "SEE LICENSE IN LICENSE.md",
+			"version": "4.11.1",
+			"resolved": "https://registry.npmjs.org/@dittolive/ditto/-/ditto-4.11.1.tgz",
+			"integrity": "sha512-Vp7ItuZE8BZGIwEPIdnv2WbILH1cb37Qjt5y9NLMhEDxdEgd56zXnQ3NSBuAk9YYXFegizhd51KJ8/LUchMxsQ==",
 			"dependencies": {
 				"@expo/config-plugins": "^9.0.11",
 				"cbor-redux": "^1.0.0",

--- a/javascript-tui/package.json
+++ b/javascript-tui/package.json
@@ -18,7 +18,7 @@
 		"dist"
 	],
 	"dependencies": {
-		"@dittolive/ditto": "^4.10.0",
+		"@dittolive/ditto": "^4.11.1",
 		"dotenv": "^16.4.5",
 		"ink": "^4.1.0",
 		"meow": "^11.0.0",

--- a/javascript-tui/source/cli.js
+++ b/javascript-tui/source/cli.js
@@ -87,6 +87,11 @@ ditto.updateTransportConfig(config => {
 // disable sync with v3 peers, required for DQL
 await ditto.disableSyncWithV3();
 
+// Disable DQL strict mode
+// when set to false, collection definitions are no longer required. SELECT queries will return and display all fields by default.
+// https://docs.ditto.live/dql/strict-mode
+ await ditto.store.execute('ALTER SYSTEM SET DQL_STRICT_MODE = false')
+
 ditto.startSync();
 
 process.on('uncaughtException', err => {


### PR DESCRIPTION
## 📌 Linear Ticket

Please include a link to the corresponding Linear issue:

https://linear.app/ditto/issue/MAR-161/update-quickstarts-to-4111-and-set-dql-strict-mode-=-false

> Example: https://linear.app/ditto/issue/ABC-1234/short-description-here
---

## 📝 Description of the Change

- Updates the Ditto SDK to 4.11.1
- Sets Strict Mode to equal false
- Updated the README file with links to the proper SDK version and explain how to properly run on Windows

> Provide a concise summary of what this PR does.
> Include context, reasoning behind the change, and any relevant implementation details.

---

## 🧪 Local Testing Summary

Please indicate which platforms this change was tested on:

- [x] Windows
- [x] macOS
- [ ] Linux x86
- [ ] Linux ARM

Please indicate if you tested on emulator, simulator, or physical mobile devices:
- [ ] Emulator
- [ ] Simulator
- [ ] Virtual Machine
- [x] Physical Device

> ✅ Reminder: You are responsible for testing this change on all platforms the application supports.  
> If you are unable to test on a platform, please coordinate with another team member or request assistance.

---

## 📷 Screenshots (if applicable)
> Add screenshots or demo gifs/videos if this PR includes UI changes or notable behavior differences.

No UI changes made.
