### PR TITLE
Javascript Web:  Update to 4.11, set strict mode to false, and update README

### DIFF
--- a/javascript-web/README.md
+++ b/javascript-web/README.md
@@ -6,6 +6,12 @@ the Ditto SDK in a client-side app running in the browser.
 
 ![JS Web Ditto Screenshot](../.github/assets/js-web-ditto-screenshot.png)
 
+## Documentation
+
+- [Javascript Install Guide](https://docs.ditto.live/sdk/latest/install-guides/js)
+- [Javascript API Reference](https://software.ditto.live/js/Ditto/4.11.1/api-reference/)
+- [Javascript Release Notes](https://docs.ditto.live/sdk/latest/release-notes/js)
+
 ## Getting Started
 
 To get started, you'll first need to create an app in the [Ditto Portal][0]

--- a/javascript-web/eslint.config.js
+++ b/javascript-web/eslint.config.js
@@ -1,14 +1,18 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
-import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended'
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
+import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
 
 export default tseslint.config(
   { ignores: ['dist'] },
   {
-    extends: [js.configs.recommended, ...tseslint.configs.recommended, eslintPluginPrettierRecommended],
+    extends: [
+      js.configs.recommended,
+      ...tseslint.configs.recommended,
+      eslintPluginPrettierRecommended,
+    ],
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
       ecmaVersion: 2020,
@@ -26,4 +30,4 @@ export default tseslint.config(
       ],
     },
   },
-)
+);

--- a/javascript-web/package-lock.json
+++ b/javascript-web/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ditto-quickstart-vite",
       "version": "0.0.0",
       "dependencies": {
-        "@dittolive/ditto": "^4.10.0",
+        "@dittolive/ditto": "^4.11.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -2461,10 +2461,9 @@
       "license": "MIT"
     },
     "node_modules/@dittolive/ditto": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/@dittolive/ditto/-/ditto-4.10.2.tgz",
-      "integrity": "sha512-cZTw+xrgE18ps77UKXC8tYDlghf4JzNoDGqtPFqVNoUzi5VA3aPfYwFq62VlSRJxVQUPhEEvDV/sE56h5tw4KQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@dittolive/ditto/-/ditto-4.11.1.tgz",
+      "integrity": "sha512-Vp7ItuZE8BZGIwEPIdnv2WbILH1cb37Qjt5y9NLMhEDxdEgd56zXnQ3NSBuAk9YYXFegizhd51KJ8/LUchMxsQ==",
       "dependencies": {
         "@expo/config-plugins": "^9.0.11",
         "cbor-redux": "^1.0.0",

--- a/javascript-web/package.json
+++ b/javascript-web/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@dittolive/ditto": "^4.10.0",
+    "@dittolive/ditto": "^4.11.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/javascript-web/src/App.tsx
+++ b/javascript-web/src/App.tsx
@@ -67,6 +67,14 @@ const App = () => {
 
         // disable sync with v3 peers, required for DQL
         await ditto.current.disableSyncWithV3();
+
+        // Disable DQL strict mode
+        // when set to false, collection definitions are no longer required. SELECT queries will return and display all fields by default.
+        // https://docs.ditto.live/dql/strict-mode
+        await ditto.current.store.execute(
+          'ALTER SYSTEM SET DQL_STRICT_MODE = false',
+        );
+
         ditto.current.startSync();
 
         // Register a subscription, which determines what data syncs to this peer


### PR DESCRIPTION
## 📌 Linear Ticket

Please include a link to the corresponding Linear issue:

https://linear.app/ditto/issue/MAR-161/update-quickstarts-to-4111-and-set-dql-strict-mode-=-false

> Example: https://linear.app/ditto/issue/ABC-1234/short-description-here
---

## 📝 Description of the Change

- Updates the Ditto SDK to 4.11.1
- Sets Strict Mode to equal false
- Updated the README file with links to the proper SDK version and links to documentation so it matches the other Quickstarts
- Ran prettier on files for linting

> Provide a concise summary of what this PR does.
> Include context, reasoning behind the change, and any relevant implementation details.

---

## 🧪 Local Testing Summary

Please indicate which platforms this change was tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux x86
- [ ] Linux ARM

Please indicate if you tested on emulator, simulator, or physical mobile devices:
- [ ] Emulator
- [ ] Simulator
- [ ] Virtual Machine
- [x] Physical Device

> ✅ Reminder: You are responsible for testing this change on all platforms the application supports.  
> If you are unable to test on a platform, please coordinate with another team member or request assistance.

---

## 📷 Screenshots (if applicable)
> Add screenshots or demo gifs/videos if this PR includes UI changes or notable behavior differences.

No UI changes made.
