### PR TITLE
Android Kotlin: Update for 4.11, strict mode = false, update readme, fix theming, and update dependicies

### DIFF
--- a/android-kotlin/QuickStartTasks/app/build.gradle.kts
+++ b/android-kotlin/QuickStartTasks/app/build.gradle.kts
@@ -6,6 +6,7 @@ import java.util.Properties
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
+    alias(libs.plugins.compose.compiler)
 }
 
 // Load properties from the .env file at the repository root
@@ -33,7 +34,7 @@ androidComponents {
             "DITTO_APP_ID",
             BuildConfigField(
                 "String",
-                "${prop["DITTO_APP_ID"]}",
+                "\"${prop["DITTO_APP_ID"]}\"",
                 "Ditto application ID"
             )
         )
@@ -41,7 +42,7 @@ androidComponents {
             "DITTO_PLAYGROUND_TOKEN",
             BuildConfigField(
                 "String",
-                "${prop["DITTO_PLAYGROUND_TOKEN"]}",
+                "\"${prop["DITTO_PLAYGROUND_TOKEN"]}\"",
                 "Ditto online playground authentication token"
             )
         )
@@ -50,7 +51,7 @@ androidComponents {
             "DITTO_AUTH_URL",
             BuildConfigField(
                 "String",
-                "${prop["DITTO_AUTH_URL"]}",
+                "\"${prop["DITTO_AUTH_URL"]}\"",
                 "Ditto Auth URL"
             )
         )
@@ -59,7 +60,7 @@ androidComponents {
             "DITTO_WEBSOCKET_URL",
             BuildConfigField(
                 "String",
-                "${prop["DITTO_WEBSOCKET_URL"]}",
+                "\"${prop["DITTO_WEBSOCKET_URL"]}\"",
                 "Ditto Websocket URL"
             )
         )
@@ -128,7 +129,18 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.datastore.preferences)
 
+    implementation(platform(libs.koin.bom))
+    implementation(libs.koin.core)
+    implementation(libs.koin.android)
+    implementation(libs.koin.androidx.compose)
+    implementation(libs.koin.androidx.compose.navigation)
+
+    // Ditto SDK
+    implementation(libs.live.ditto)
+
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines)
+
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))
@@ -137,6 +149,4 @@ dependencies {
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
 
-    // Ditto SDK
-    implementation("live.ditto:ditto:4.10.0")
 }

--- a/android-kotlin/QuickStartTasks/app/src/main/java/live/ditto/quickstart/tasks/TasksApplication.kt
+++ b/android-kotlin/QuickStartTasks/app/src/main/java/live/ditto/quickstart/tasks/TasksApplication.kt
@@ -2,6 +2,10 @@ package live.ditto.quickstart.tasks
 
 import android.app.Application
 import android.content.Context
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import live.ditto.Ditto
 import live.ditto.DittoIdentity
 import live.ditto.DittoLogLevel
@@ -11,6 +15,15 @@ import live.ditto.quickstart.tasks.DittoHandler.Companion.ditto
 import live.ditto.transports.DittoTransportConfig
 
 class TasksApplication : Application() {
+
+
+    // Create a CoroutineScope
+    // Use SupervisorJob so if one coroutine launched in this scope fails, it doesn't cancel the scope
+    //
+    // https://developer.android.com/kotlin/coroutines/coroutines-adv
+    // Dispatchers.IO - This dispatcher is optimized to perform disk or network I/O outside of the main thread.
+    private val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
 
     companion object {
         private var instance: TasksApplication? = null
@@ -26,10 +39,12 @@ class TasksApplication : Application() {
     
     override fun onCreate() {
         super.onCreate()
-        setupDitto()
+        ioScope.launch {
+            setupDitto()
+        }
     }
 
-    private fun setupDitto() {
+    private suspend fun setupDitto() {
         val androidDependencies = DefaultAndroidDittoDependencies(applicationContext)
 
         //read values from build.gradle.kts (Module:app) which reads from environment file
@@ -57,6 +72,8 @@ class TasksApplication : Application() {
             // Set the Ditto Websocket URL
             config.connect.websocketUrls.add(webSocketURL)
         }
+
+        ditto.store.execute("ALTER SYSTEM SET DQL_STRICT_MODE = false");
 
         // disable sync with v3 peers, required for DQL
         ditto.disableSyncWithV3()

--- a/android-kotlin/QuickStartTasks/app/src/main/java/live/ditto/quickstart/tasks/ui/theme/Theme.kt
+++ b/android-kotlin/QuickStartTasks/app/src/main/java/live/ditto/quickstart/tasks/ui/theme/Theme.kt
@@ -9,7 +9,12 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
 
 private val DarkColorScheme = darkColorScheme(
     primary = Purple80,
@@ -48,6 +53,20 @@ fun QuickStartTasksTheme(
 
         darkTheme -> DarkColorScheme
         else -> LightColorScheme
+    }
+
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as Activity).window
+            // Set the status bar color to match the theme
+            window.statusBarColor = Color.Transparent.toArgb()
+            // Set the navigation bar color to match the theme
+            window.navigationBarColor = if (darkTheme) Color.Black.toArgb() else Color.White.toArgb()
+            // Set the system bar icons to be light or dark based on the theme
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
+            WindowCompat.getInsetsController(window, view).isAppearanceLightNavigationBars = !darkTheme
+        }
     }
 
     MaterialTheme(

--- a/android-kotlin/QuickStartTasks/build.gradle.kts
+++ b/android-kotlin/QuickStartTasks/build.gradle.kts
@@ -2,5 +2,6 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.jetbrains.kotlin.android) apply false
+    alias(libs.plugins.compose.compiler) apply false
 }
 

--- a/android-kotlin/QuickStartTasks/gradle/libs.versions.toml
+++ b/android-kotlin/QuickStartTasks/gradle/libs.versions.toml
@@ -1,17 +1,21 @@
 [versions]
-agp = "8.5.2"
-kotlin = "1.9.24"
-coreKtx = "1.15.0"
+agp = "8.9.3"
+kotlin = "2.1.0"
+coreKtx = "1.16.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
-lifecycleRuntimeKtx = "2.8.7"
-activityCompose = "1.9.3"
-composeBom = "2024.10.01"
-navigationCompose = "2.8.3"
-runtimeLivedata = "1.7.5"
-appcompat = "1.7.0"
-datastorePreferences = "1.1.1"
+lifecycleRuntimeKtx = "2.9.2"
+activityCompose = "1.10.1"
+composeBom = "2025.07.00"
+navigationCompose = "2.9.2"
+runtimeLivedata = "1.8.3"
+appcompat = "1.7.1"
+datastorePreferences = "1.1.7"
+koin-bom = "4.1.0"
+coroutes-tests = "1.10.2"
+ditto = "4.11.1"
+monitor = "1.7.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -32,8 +36,17 @@ androidx-navigation-compose = { module = "androidx.navigation:navigation-compose
 androidx-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata", version.ref = "runtimeLivedata" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", name = "datastore-preferences", version.ref = "datastorePreferences" }
+koin-bom = { group = "io.insert-koin", name = "koin-bom", version.ref = "koin-bom" }
+koin-core = { group = "io.insert-koin", name = "koin-core" }
+koin-android = { group = "io.insert-koin", name = "koin-android" }
+koin-androidx-compose = { group = "io.insert-koin", name = "koin-androidx-compose" }
+koin-androidx-compose-navigation = { group = "io.insert-koin", name = "koin-androidx-compose-navigation" }
+live-ditto = { group = "live.ditto", name = "ditto", version.ref = "ditto" }
+kotlinx-coroutines = {group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutes-tests" }
+androidx-monitor = { group = "androidx.test", name = "monitor", version.ref = "monitor" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 

--- a/android-kotlin/QuickStartTasks/gradle/wrapper/gradle-wrapper.properties
+++ b/android-kotlin/QuickStartTasks/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Nov 01 13:13:02 EDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android-kotlin/README.md
+++ b/android-kotlin/README.md
@@ -13,7 +13,7 @@ After you have completed the [common prerequisites] you will need the following:
 ## Documentation
 
 - [Kotlin Install Guide](https://docs.ditto.live/install-guides/kotlin)
-- [Kotlin API Reference](https://software.ditto.live/android/Ditto/4.8.2/api-reference/)
+- [Kotlin API Reference](https://software.ditto.live/android/Ditto/4.11.1/api-reference/)
 - [Kotlin SDK Release Notes](https://docs.ditto.live/release-notes/kotlin)
 
 [common prerequisites]: https://github.com/getditto/quickstart#common-prerequisites
@@ -55,7 +55,7 @@ Android Studio to automatically download the Ditto SDK from Maven Central and
 add it to the project:
 
 ```kotlin
-    implementation("live.ditto:ditto:4.8.2")
+    implementation("live.ditto:ditto:4.11.1")
 ```
 
 To use a newer version of the SDK, change the version number in this line.


### PR DESCRIPTION
## 📌 Linear Ticket

Please include a link to the corresponding Linear issue:

https://linear.app/ditto/issue/MAR-161/update-quickstarts-to-4111-and-set-dql-strict-mode-=-false

> Example: https://linear.app/ditto/issue/ABC-1234/short-description-here
---

## 📝 Description of the Change

- Updates the Ditto SDK to 4.11.1
- Updated various Android Dependencies
- Moved JVM from 1.8 to 1.11  
- Sets Strict Mode to equal false
- Updated the README file with links to the proper SDK version and links to documentation so it matches the other Quickstarts
- Updated theme to fix rendering bug where bottom UI wasn't properly drawing based on theme

> Provide a concise summary of what this PR does.
> Include context, reasoning behind the change, and any relevant implementation details.

---

## 🧪 Local Testing Summary

Please indicate which platforms this change was tested on:

- [] Windows
- [x] macOS
- [ ] Linux x86
- [ ] Linux ARM

Please indicate if you tested on emulator, simulator, or physical mobile devices:
- [x] Emulator
- [] Simulator
- [ ] Virtual Machine
- [x] Physical Device

> ✅ Reminder: You are responsible for testing this change on all platforms the application supports.  
> If you are unable to test on a platform, please coordinate with another team member or request assistance.

---

## 📷 Screenshots (if applicable)
> Add screenshots or demo gifs/videos if this PR includes UI changes or notable behavior differences.

UI was updated so bottom navigation can render properly in dark vs light mode:
<img width="556" height="1245" alt="Screenshot 2025-07-28 at 4 59 51 PM" src="https://github.com/user-attachments/assets/9a7cda6b-b9d5-49ae-b5dc-e2efc6f985b1" />

<img width="561" height="1201" alt="Screenshot 2025-07-28 at 5 00 59 PM" src="https://github.com/user-attachments/assets/c8e97ddc-1582-4738-807f-3b2daaf85634" />
