### PR TITLE
Use `jsonData()` instead of `jsonString()`

### DIFF
--- a/swift/Tasks/TaskModel.swift
+++ b/swift/Tasks/TaskModel.swift
@@ -56,10 +56,10 @@ extension TaskModel: Equatable {
 
 extension TaskModel: Codable {
 
-    /// Returns optional instance decoded from `QueryResultItem.jsonString()`
-    init?(_ json: String) {
+    /// Returns optional instance decoded from `QueryResultItem.jsonData()`
+    init?(_ jsonData: Data) {
         do {
-            self = try JSONDecoder().decode(Self.self, from: Data(json.utf8))
+            self = try JSONDecoder().decode(Self.self, from: jsonData)
         } catch {
             print("ERROR:", error.localizedDescription)
             return nil

--- a/swift/Tasks/TasksListScreen.swift
+++ b/swift/Tasks/TasksListScreen.swift
@@ -28,7 +28,7 @@ class TasksListScreenViewModel: ObservableObject {
             [weak self] result in
             guard let self = self else { return }
             self.tasks = result.items.compactMap {
-                TaskModel($0.jsonString())
+                TaskModel($0.jsonData())
             }
         }
     }


### PR DESCRIPTION
Use of `jsonString()` is discouraged in Swift and will be deprecated soon. The API to use for this is `jsonData()`.