### PR TITLE
Dotnet Maui - Update to 4.11.1, disable strict mode, and allow debugging in Rider/Visual Studio on PC

### DIFF
--- a/dotnet-maui/DittoMauiTasksApp/DittoMauiTasksApp.csproj
+++ b/dotnet-maui/DittoMauiTasksApp/DittoMauiTasksApp.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041.0</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))">net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">net9.0-windows10.0.19041.0;net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Linux'))">net9.0-android</TargetFrameworks>
         <OutputType>Exe</OutputType>
         <RootNamespace>DittoMauiTasksApp</RootNamespace>
         <UseMaui>true</UseMaui>
@@ -38,7 +40,7 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.1" />
-        <PackageReference Include="Ditto" Version="4.11.0" />
+        <PackageReference Include="Ditto" Version="4.11.1" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
         <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
         <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />

--- a/dotnet-maui/DittoMauiTasksApp/MauiProgram.cs
+++ b/dotnet-maui/DittoMauiTasksApp/MauiProgram.cs
@@ -51,14 +51,20 @@ public static class MauiProgram
             false,  // This is required to be set to false to use the correct URLs
             authUrl), Path.Combine(FileSystem.Current.AppDataDirectory, "ditto"));
 
+        // Set the transport configuration
+        // https://docs.ditto.live/sdk/latest/sync/customizing-transport-configurations#enabling-and-disabling-transports
         ditto.UpdateTransportConfig(config =>
         {
             // Add the websocket URL to the transport configuration.
             config.Connect.WebsocketUrls.Add(websocketUrl);
         });
-        
+
         // disable sync with v3 peers, required for DQL
         ditto.DisableSyncWithV3();
+
+        // Disable DQL strict mode
+        // https://docs.ditto.live/dql/strict-mode
+        ditto.Store.ExecuteAsync("ALTER SYSTEM SET DQL_STRICT_MODE = false").Wait();
 
         return ditto;
     }

--- a/dotnet-maui/README.md
+++ b/dotnet-maui/README.md
@@ -13,7 +13,7 @@
 ## Documentation
 
 - [Ditto C# .NET SDK Install Guide](https://docs.ditto.live/install-guides/c-sharp)
-- [Ditto C# .NET SDK API Reference](https://software.ditto.live/dotnet/Ditto/4.9.1/api-reference/)
+- [Ditto C# .NET SDK API Reference](https://software.ditto.live/dotnet/Ditto/4.11.1/api-reference/)
 ### Restore Packages
 
 ```sh


### PR DESCRIPTION
## 📌 Linear Ticket

Please include a link to the corresponding Linear issue:

https://linear.app/ditto/issue/MAR-161/update-quickstarts-to-4111-and-set-dql-strict-mode-=-false

> Example: https://linear.app/ditto/issue/ABC-1234/short-description-here
---

## 📝 Description of the Change

- Updates the Ditto SDK to 4.11.1
- Sets Strict Mode to equal false
- Updated the project file so that you can debug in Rider and in Visual Studio on Windows by setting up the platform targets based on what OS you are on
- Updated the README file with links to the proper SDK version and use of new .env option

> Provide a concise summary of what this PR does.
> Include context, reasoning behind the change, and any relevant implementation details.

---

## 🧪 Local Testing Summary

Please indicate which platforms this change was tested on:

- [x] Windows
- [x] macOS
- [ ] Linux x86
- [ ] Linux ARM

Please indicate if you tested on emulator, simulator, or physical mobile devices:
- [x] Emulator
- [x] Simulator
- [ ] Virtual Machine
- [x] Physical Device

> ✅ Reminder: You are responsible for testing this change on all platforms the application supports.  
> If you are unable to test on a platform, please coordinate with another team member or request assistance.

---

## 📷 Screenshots (if applicable)
> Add screenshots or demo gifs/videos if this PR includes UI changes or notable behavior differences.

No UI changes made.
