### PR TITLE
chore: add `CLAUDE.md` file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,10 @@ All apps load configuration from the `.env` file at the repository root. The loa
 ## Important Notes
 
 1. **Production Warning**: These apps use "Online Playground" identity which is NOT suitable for production
+   - For production environments, configure use the "Online with Authentication" identity to authenticate with
+   your identity system and retrieve a secret token prior to syncing with Ditto. 
+   - Refer to the [Authentication and Authorization](https://docs.ditto.live/key-concepts/authentication-and-authorization#online-with-authentication)
+   for detailed instructions on configuring identity for production use.
 2. **Cross-Platform Consistency**: All apps implement the same data model for interoperability (though field names may vary slightly)
 3. **Platform Best Practices**: Each app follows its platform's conventions and patterns
 4. **Real Device Testing**: For full P2P functionality, test on real devices rather than simulators


### PR DESCRIPTION
This PR adds a `CLAUDE.md` file to save some tokens on future Claude Code sessions.

While generating this, Claude found deviations in the data model implementation that should be revisited at some point. Logged in [SDKS-1434](https://linear.app/ditto/issue/SDKS-1434/inconsistent-data-models-between-quickstart-apps)

> ⏺ You're right to point that out. Looking at the actual data model implementations across the codebase, there are indeed variations in field
>   naming between platforms:
> 
>   1. Android/Kotlin uses: title, done, deleted
>   2. JavaScript/React/Swift/Rust use: text, isCompleted
>   3. Some implementations include a deleted field for soft deletes, others don't
> 
>   This inconsistency across platforms could cause interoperability issues since these apps are supposed to sync data between devices. The
>   CLAUDE.md documentation correctly notes these variations, which is important for developers to understand when working across different
>   platform implementations.