### PR TITLE
feat(rust): Add Presence Graph to rust tui example

### DIFF
--- a/rust-tui/Cargo.lock
+++ b/rust-tui/Cargo.lock
@@ -443,6 +443,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
+ "tui-nodes",
  "uuid",
 ]
 
@@ -1815,6 +1816,16 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tui-nodes"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a48253c4027b483ce44a8318c6b3513fe0bc0692757a6bc7e22a23e76b25b016"
+dependencies = [
+ "log",
+ "ratatui",
 ]
 
 [[package]]

--- a/rust-tui/Cargo.toml
+++ b/rust-tui/Cargo.toml
@@ -33,4 +33,5 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 tokio-stream = { version = "0.1.17", features = ["sync"] }
 uuid = "1.13"
+tui-nodes = "0.9.0"
 

--- a/rust-tui/src/tui/todolist.rs
+++ b/rust-tui/src/tui/todolist.rs
@@ -238,7 +238,7 @@ impl Todolist {
             // Truncate the peer key to a more readable format
             .map(|peer_key| format!("{}.+{}", &peer_key[..2], &peer_key[peer_key.len() - 7..]))
             .collect::<Vec<_>>();
-        let mut peer_nodes = peer_keys
+        let peer_nodes = peer_keys
             .iter()
             .map(|peer| NodeLayout::new((12, 3)).with_title(peer))
             .collect::<Vec<_>>();


### PR DESCRIPTION
Not sure if it's even wanted. But I thought this was a fun idea to show off our presence graphs.

The new [tui-nodes](https://crates.io/crates/tui-nodes) isn't very well documented, but it does have an MIT license.

Here's a screenshot of the new `TodoMode`:
<img width="1258" height="742" alt="image" src="https://github.com/user-attachments/assets/06df2fa5-fc99-4c0d-9a51-211ebe9755d6" />

NOTE: I'm not entirely sure why it is so right padded.