### PR TITLE
chore: add ci build for swift quickstart

### DIFF
--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -67,10 +67,9 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             ONLY_ACTIVE_ARCH=NO
 
-      - name: Build for macOS (if supported)
+      - name: Build for macOS
         working-directory: swift
         run: |
-          # Try to build for macOS as well if the project supports it
           xcodebuild build \
             -project Tasks.xcodeproj \
             -scheme Tasks \
@@ -80,8 +79,7 @@ jobs:
             SWIFT_TREAT_WARNINGS_AS_ERRORS=NO \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGNING_ALLOWED=NO \
-            || echo "macOS build not supported, skipping"
+            CODE_SIGNING_ALLOWED=NO
 
       - name: Run Swift Tests (if available)
         working-directory: swift


### PR DESCRIPTION
This PR adds support for building the swift quickstart for any new PR that targets the swift quickstart app.