### PR TITLE
chore: add kotlin-multiplatform CI build

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -184,7 +184,7 @@ jobs:
 
       - name: Build project
         working-directory: kotlin-multiplatform
-        run: ./gradlew build
+        run: ./gradlew assemble
 
       - name: Run tests
         working-directory: kotlin-multiplatform

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -158,3 +158,34 @@ jobs:
           # Test that the app can show SDK version
           ./build/taskscpp --ditto-sdk-version
           echo "✅ SDK version command works"
+
+  kotlin-multiplatform:
+    name: Kotlin Multiplatform (ubuntu-24.04)
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v3
+
+      - name: Create .env file
+        run: |
+          echo "DITTO_APP_ID=${{ secrets.DITTO_APP_ID }}" > .env
+          echo "DITTO_PLAYGROUND_TOKEN=${{ secrets.DITTO_PLAYGROUND_TOKEN }}" >> .env
+          echo "DITTO_AUTH_URL=${{ secrets.DITTO_AUTH_URL }}" >> .env
+          echo "DITTO_WEBSOCKET_URL=${{ secrets.DITTO_WEBSOCKET_URL }}" >> .env
+
+      - name: Build project
+        working-directory: kotlin-multiplatform
+        run: ./gradlew build
+
+      - name: Run tests
+        working-directory: kotlin-multiplatform
+        run: ./gradlew test

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -173,7 +173,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Create .env file
         run: |


### PR DESCRIPTION
This PR adds a build step to our PR checks to build the kotlin-multiplatform project.