### PR TITLE
chore: Update CODEOWNERS for Android Java and Kotlin, add reviewers to new apps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,16 +7,22 @@
 * @getditto/sdk-engineers
 
 # SDK-specific owners
-/android-cpp/        @kristopherjohnson @teodorciuraru
-/android-java/       @phatblat @busec0
-/android-kotlin/     @phatblat @busec0
-/cpp-tui/            @kristopherjohnson @teodorciuraru
-/dotnet-maui/        @busec0 @phatblat
-/dotnet-tui/         @busec0 @phatblat
-/flutter_quickstart/ @cameron1024 @teodorciuraru
-/java-spring/        @phatblat @busec0
-/javascript-tui/     @konstantinbe @pvditto @teodorciuraru
-/javascript-web/     @konstantinbe @pvditto @teodorciuraru
-/react-native/       @teodorciuraru @kristopherjohnson
-/rust-tui/           @kristopherjohnson @cameron1024
-/swift/              @phatblat @konstantinbe @busec0
+/android-cpp/            @kristopherjohnson @teodorciuraru
+/android-java/           @phatblat @busec0
+/android-kotlin/         @phatblat @busec0
+/cpp-tui/                @kristopherjohnson @teodorciuraru
+/dotnet-maui/            @busec0 @phatblat
+/dotnet-tui/             @busec0 @phatblat
+/dotnet-winforms/        @busec0 @phatblat
+/flutter_app/            @cameron1024 @teodorciuraru
+/java-spring/            @phatblat @busec0
+/javascript-tui/         @konstantinbe @pvditto @teodorciuraru
+/javascript-web/         @konstantinbe @pvditto @teodorciuraru
+/kotlin-multiplatform/   @busec0 @phatblat
+/react-native/           @teodorciuraru @kristopherjohnson
+/react-native-expo/      @teodorciuraru @kristopherjohnson
+/rust-tui/               @kristopherjohnson @cameron1024
+/swift/                  @phatblat @konstantinbe @busec0
+
+# TODO: Enable once we have 2 reviewers for Edge Server
+# /edge-server/            @baxterjo


### PR DESCRIPTION
Replacing @anyercastillo with @busec0 on Android projects.

Added paths:
- `/android-kotlin/`
- `/dotnet-winforms/`
- `/flutter_app/` (renamed from `/flutter_quickstart/`)
- `/java-spring/`
- `/kotlin-multiplatform/`
- `/react-native-expo/`

`/edge-server` is new, added as a comment because we need at least 2 code owners so they can approve each others' PRs.