### PR TITLE
chore: auto-build release branches

### DIFF
--- a/.github/workflows/android-cpp-browserstack.yml
+++ b/.github/workflows/android-cpp-browserstack.yml
@@ -7,12 +7,16 @@ name: android-cpp-browserstack
 
 on:
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - 'sdk-*'
     paths:
       - 'android-cpp/**'
       - '.github/workflows/android-cpp-browserstack.yml'
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'sdk-*'
     paths:
       - 'android-cpp/**'
       - '.github/workflows/android-cpp-browserstack.yml'

--- a/.github/workflows/javascript-web-browserstack.yml
+++ b/.github/workflows/javascript-web-browserstack.yml
@@ -2,12 +2,16 @@ name: javascript-web-browserstack
 
 on:
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - 'sdk-*'
     paths:
       - 'javascript-web/**'
       - '.github/workflows/javascript-web-browserstack.yml'
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'sdk-*'
     paths:
       - 'javascript-web/**'
       - '.github/workflows/javascript-web-browserstack.yml'

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,9 +6,13 @@ name: PR Checks
 
 on:
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - 'sdk-*'
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'sdk-*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/react-native-ci.yml
+++ b/.github/workflows/react-native-ci.yml
@@ -1,13 +1,17 @@
 name: React Native CI
 
 on:
-  push:
-    branches: [ main ]
+  pull_request:
+    branches:
+      - main
+      - 'sdk-*'
     paths: 
       - 'react-native/**'
-  pull_request:
-    branches: [ main ]
-    paths:
+  push:
+    branches:
+      - main
+      - 'sdk-*'
+    paths: 
       - 'react-native/**'
 
 concurrency:

--- a/.github/workflows/react-native-expo-ci.yml
+++ b/.github/workflows/react-native-expo-ci.yml
@@ -2,11 +2,15 @@ name: React Native Expo CI
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - 'sdk-*'
     paths: 
       - 'react-native-expo/**'
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - 'sdk-*'
     paths:
       - 'react-native-expo/**'
 

--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -6,9 +6,13 @@ name: Swift CI
 
 on:
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - 'sdk-*'
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'sdk-*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This PR updates our github workflow rules to automatically build branches starting with sdk-. This is the format we will use for release branches going forward.