### PR TITLE
chore: update ditto version to 4.12.1

### DIFF
--- a/android-cpp/QuickStartTasksCPP/app/build.gradle.kts
+++ b/android-cpp/QuickStartTasksCPP/app/build.gradle.kts
@@ -135,7 +135,7 @@ android {
 
 dependencies {
     // Ditto C++ SDK for Android
-    implementation("live.ditto:ditto-cpp:4.11.1")
+    implementation("live.ditto:ditto-cpp:4.12.1")
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/android-java/README.md
+++ b/android-java/README.md
@@ -13,7 +13,7 @@ After you have completed the [common prerequisites] you will need the following:
 ## Documentation
 
 - [Install Guide](https://docs.ditto.live/sdk/latest/install-guides/java/android)
-- [API Reference](https://software.ditto.live/android/Ditto/4.11.1/api-reference/)
+- [API Reference](https://software.ditto.live/android/Ditto/4.12.1/api-reference/)
 - [SDK Release Notes](https://docs.ditto.live/sdk/latest/release-notes/java)
 
 [common prerequisites]: https://github.com/getditto/quickstart#common-prerequisites
@@ -54,7 +54,7 @@ This line in `gradle/libs.versions.toml` specifies which version of the Ditto
 SDK to use:
 
 ```kotlin
-ditto = "4.11.1"
+ditto = "4.12.1"
 ```
 
 To use a newer version of the SDK, change the version number on this line.

--- a/android-kotlin/QuickStartTasks/gradle/libs.versions.toml
+++ b/android-kotlin/QuickStartTasks/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ appcompat = "1.7.1"
 datastorePreferences = "1.1.7"
 koin-bom = "4.1.0"
 coroutines-tests = "1.10.2"
-ditto = "4.11.1"
+ditto = "4.12.1"
 monitor = "1.7.2"
 
 [libraries]

--- a/android-kotlin/README.md
+++ b/android-kotlin/README.md
@@ -13,7 +13,7 @@ After you have completed the [common prerequisites] you will need the following:
 ## Documentation
 
 - [Kotlin Install Guide](https://docs.ditto.live/install-guides/kotlin)
-- [Kotlin API Reference](https://software.ditto.live/android/Ditto/4.11.1/api-reference/)
+- [Kotlin API Reference](https://software.ditto.live/android/Ditto/4.12.1/api-reference/)
 - [Kotlin SDK Release Notes](https://docs.ditto.live/release-notes/kotlin)
 
 [common prerequisites]: https://github.com/getditto/quickstart#common-prerequisites
@@ -55,7 +55,7 @@ Android Studio to automatically download the Ditto SDK from Maven Central and
 add it to the project:
 
 ```kotlin
-    implementation("live.ditto:ditto:4.11.1")
+    implementation("live.ditto:ditto:4.12.1")
 ```
 
 To use a newer version of the SDK, change the version number in this line.

--- a/dotnet-maui/DittoMauiTasksApp/DittoMauiTasksApp.csproj
+++ b/dotnet-maui/DittoMauiTasksApp/DittoMauiTasksApp.csproj
@@ -40,7 +40,7 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.1" />
-        <PackageReference Include="Ditto" Version="4.11.1" />
+        <PackageReference Include="Ditto" Version="4.12.1" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
         <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
         <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />

--- a/dotnet-maui/README.md
+++ b/dotnet-maui/README.md
@@ -13,7 +13,7 @@
 ## Documentation
 
 - [Ditto C# .NET SDK Install Guide](https://docs.ditto.live/install-guides/c-sharp)
-- [Ditto C# .NET SDK API Reference](https://software.ditto.live/dotnet/Ditto/4.11.1/api-reference/)
+- [Ditto C# .NET SDK API Reference](https://software.ditto.live/dotnet/Ditto/4.12.1/api-reference/)
 ### Restore Packages
 
 ```sh

--- a/dotnet-tui/DittoDotNetTasksConsole/DittoDotNetTasksConsole.csproj
+++ b/dotnet-tui/DittoDotNetTasksConsole/DittoDotNetTasksConsole.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ditto" Version="4.11.1" />
+    <PackageReference Include="Ditto" Version="4.12.1" />
     <PackageReference Include="Terminal.Gui" Version="1.17.1" />
   </ItemGroup>
 

--- a/dotnet-winforms/README.md
+++ b/dotnet-winforms/README.md
@@ -11,7 +11,7 @@
 ## Documentation
 
 - [Ditto C# .NET SDK Install Guide](https://docs.ditto.live/install-guides/c-sharp)
-- [Ditto C# .NET SDK API Reference](https://software.ditto.live/dotnet/Ditto/4.11.1/api-reference/)
+- [Ditto C# .NET SDK API Reference](https://software.ditto.live/dotnet/Ditto/4.12.1/api-reference/)
 
 
 ## .NET Windows Forms Application 

--- a/dotnet-winforms/TasksApp/DittoTasksApp.csproj
+++ b/dotnet-winforms/TasksApp/DittoTasksApp.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ditto" Version="4.11.1" />
+    <PackageReference Include="Ditto" Version="4.12.1" />
     <PackageReference Include="System.Text.Json" Version="9.0.4" />
   </ItemGroup>
 

--- a/javascript-tui/package-lock.json
+++ b/javascript-tui/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"@dittolive/ditto": "^4.11.1",
+				"@dittolive/ditto": "^4.12.1",
 				"dotenv": "^16.4.5",
 				"ink": "^4.1.0",
 				"meow": "^11.0.0",
@@ -2425,9 +2425,10 @@
 			"license": "MIT"
 		},
 		"node_modules/@dittolive/ditto": {
-			"version": "4.11.1",
-			"resolved": "https://registry.npmjs.org/@dittolive/ditto/-/ditto-4.11.1.tgz",
-			"integrity": "sha512-Vp7ItuZE8BZGIwEPIdnv2WbILH1cb37Qjt5y9NLMhEDxdEgd56zXnQ3NSBuAk9YYXFegizhd51KJ8/LUchMxsQ==",
+			"version": "4.12.1",
+			"resolved": "https://registry.npmjs.org/@dittolive/ditto/-/ditto-4.12.1.tgz",
+			"integrity": "sha512-K2348w04pkttGf+E4OG3nHqw09BOVaxg786Qr3BiYAGEnpMxP9mFbmiAxEpLtCuYwVFpLTamAnBwiGxF1yxxog==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"@expo/config-plugins": "^9.0.11",
 				"cbor-redux": "^1.0.0",

--- a/javascript-tui/package.json
+++ b/javascript-tui/package.json
@@ -18,7 +18,7 @@
 		"dist"
 	],
 	"dependencies": {
-		"@dittolive/ditto": "^4.11.1",
+		"@dittolive/ditto": "^4.12.1",
 		"dotenv": "^16.4.5",
 		"ink": "^4.1.0",
 		"meow": "^11.0.0",

--- a/javascript-web/README.md
+++ b/javascript-web/README.md
@@ -9,7 +9,7 @@ the Ditto SDK in a client-side app running in the browser.
 ## Documentation
 
 - [Javascript Install Guide](https://docs.ditto.live/sdk/latest/install-guides/js)
-- [Javascript API Reference](https://software.ditto.live/js/Ditto/4.11.1/api-reference/)
+- [Javascript API Reference](https://software.ditto.live/js/Ditto/4.12.1/api-reference/)
 - [Javascript Release Notes](https://docs.ditto.live/sdk/latest/release-notes/js)
 
 ## Getting Started

--- a/javascript-web/package-lock.json
+++ b/javascript-web/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ditto-quickstart-vite",
       "version": "0.0.0",
       "dependencies": {
-        "@dittolive/ditto": "^4.11.1",
+        "@dittolive/ditto": "^4.12.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -2461,9 +2461,10 @@
       "license": "MIT"
     },
     "node_modules/@dittolive/ditto": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@dittolive/ditto/-/ditto-4.11.1.tgz",
-      "integrity": "sha512-Vp7ItuZE8BZGIwEPIdnv2WbILH1cb37Qjt5y9NLMhEDxdEgd56zXnQ3NSBuAk9YYXFegizhd51KJ8/LUchMxsQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@dittolive/ditto/-/ditto-4.12.1.tgz",
+      "integrity": "sha512-K2348w04pkttGf+E4OG3nHqw09BOVaxg786Qr3BiYAGEnpMxP9mFbmiAxEpLtCuYwVFpLTamAnBwiGxF1yxxog==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@expo/config-plugins": "^9.0.11",
         "cbor-redux": "^1.0.0",

--- a/javascript-web/package.json
+++ b/javascript-web/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@dittolive/ditto": "^4.11.1",
+    "@dittolive/ditto": "^4.12.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },


### PR DESCRIPTION
This PR upgrades the QS examples to use the latest release version of ditto.