### PR TITLE
Experimental: test DittoSwift v5 "All in One"

### DIFF
--- a/swift/Tasks.xcodeproj/project.pbxproj
+++ b/swift/Tasks.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		4170A8552CED346F00043F5A /* DittoObjC in Frameworks */ = {isa = PBXBuildFile; productRef = 4170A8542CED346F00043F5A /* DittoObjC */; };
 		4170A8572CED346F00043F5A /* DittoSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 4170A8562CED346F00043F5A /* DittoSwift */; };
 /* End PBXBuildFile section */
 
@@ -42,7 +41,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4170A8552CED346F00043F5A /* DittoObjC in Frameworks */,
 				4170A8572CED346F00043F5A /* DittoSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -88,7 +86,6 @@
 			);
 			name = Tasks;
 			packageProductDependencies = (
-				4170A8542CED346F00043F5A /* DittoObjC */,
 				4170A8562CED346F00043F5A /* DittoSwift */,
 			);
 			productName = Tasks;
@@ -413,18 +410,13 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/getditto/DittoSwiftPackage";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.11.0;
+				kind = exactVersion;
+				version = "5.0.0-experimental.kb-inline-objc-into-swift-sdk.5";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		4170A8542CED346F00043F5A /* DittoObjC */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 4170A8532CED346F00043F5A /* XCRemoteSwiftPackageReference "DittoSwiftPackage" */;
-			productName = DittoObjC;
-		};
 		4170A8562CED346F00043F5A /* DittoSwift */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 4170A8532CED346F00043F5A /* XCRemoteSwiftPackageReference "DittoSwiftPackage" */;

--- a/swift/Tasks.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/swift/Tasks.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftPackage",
       "state" : {
-        "revision" : "1aed269afc999d4645a72c3169f9d326f6a02771",
-        "version" : "4.11.1"
+        "revision" : "9aebf0cae164fd3d26f6d8a7dd65174104b743ee",
+        "version" : "5.0.0-experimental.kb-inline-objc-into-swift-sdk.5"
       }
     }
   ],

--- a/swift/Tasks/DittoManager.swift
+++ b/swift/Tasks/DittoManager.swift
@@ -7,17 +7,16 @@ class DittoManager: ObservableObject {
     static let shared = DittoManager()
 
     private init() {
+        var config = DittoConfig.default
+        config.databaseID = Env.DITTO_APP_ID
+        config.connect = .server(url: URL(string: Env.DITTO_AUTH_URL)!)
+
         // https://docs.ditto.live/sdk/latest/install-guides/swift#integrating-and-initializing-sync
-        ditto = Ditto(
-            identity: .onlinePlayground(
-                appID: Env.DITTO_APP_ID,
-                token: Env.DITTO_PLAYGROUND_TOKEN,
-                // This is required to be set to false to use the correct URLs
-                // This only disables cloud sync when the webSocketURL is not set explicitly
-                enableDittoCloudSync: false,
-                customAuthURL: URL(string: Env.DITTO_AUTH_URL)
-            )
-        )
+        do {
+            ditto = try Ditto.openSync(config: config)
+        } catch {
+            fatalError("Opening Ditto failed with error: \(error)")
+        }
 
         // Set the Ditto Websocket URL
         ditto.updateTransportConfig { transportConfig in

--- a/swift/Tasks/TasksListScreen.swift
+++ b/swift/Tasks/TasksListScreen.swift
@@ -38,22 +38,22 @@ class TasksListScreenViewModel: ObservableObject {
         storeObserver?.cancel()
         storeObserver = nil
 
-        if ditto.isSyncActive {
-            DittoManager.shared.ditto.stopSync()
+        if ditto.sync.isActive {
+            DittoManager.shared.ditto.sync.stop()
         }
     }
 
     func setSyncEnabled(_ newValue: Bool) throws {
-        if !ditto.isSyncActive && newValue {
+        if !ditto.sync.isActive && newValue {
             try startSync()
-        } else if ditto.isSyncActive && !newValue {
+        } else if ditto.sync.isActive && !newValue {
             stopSync()
         }
     }
 
     private func startSync() throws {
         do {
-            try ditto.startSync()
+            try ditto.sync.start()
 
             // Register a subscription, which determines what data syncs to this peer
             // https://docs.ditto.live/sdk/latest/sync/syncing-data#creating-subscriptions
@@ -70,7 +70,7 @@ class TasksListScreenViewModel: ObservableObject {
         subscription?.cancel()
         subscription = nil
 
-        ditto.stopSync()
+        ditto.sync.stop()
     }
 
     func toggleComplete(task: TaskModel) {


### PR DESCRIPTION
Testing `DittoSwift` as an all-in-one build, independent of DittoObjC (which is currently deprecated and scheduled for removal in v5).