### PR TITLE
refactor(ci): use BrowserStack GitHub Actions

### DIFF
--- a/.github/workflows/java-spring-ci.yml
+++ b/.github/workflows/java-spring-ci.yml
@@ -134,39 +134,19 @@ jobs:
         echo "DITTO_AUTH_URL=${{ secrets.DITTO_AUTH_URL }}" >> .env
         echo "DITTO_WEBSOCKET_URL=${{ secrets.DITTO_WEBSOCKET_URL }}" >> .env
     
-    - name: Install BrowserStack Local binary
-      run: |
-        curl -O "https://www.browserstack.com/browserstack-local/BrowserStackLocal-darwin-x64.zip"
-        unzip BrowserStackLocal-darwin-x64.zip
-        chmod +x BrowserStackLocal
+    - name: BrowserStack Env Setup
+      uses: 'browserstack/github-actions/setup-env@master'
+      with:
+        username:  ${{ secrets.BROWSERSTACK_USERNAME }}
+        access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+        build-name: 'Java Spring Selenium Tests #${{ github.run_number }}'
+        project-name: 'Ditto Java Spring Tasks'
 
-    - name: Start BrowserStack Local tunnel 
-      run: |
-        echo "Starting BrowserStack Local tunnel..."
-        nohup ./BrowserStackLocal --key "${{ secrets.BROWSERSTACK_ACCESS_KEY }}" \
-          --daemon-mode > browserstack-local.log 2>&1 &
-        
-        # Wait for tunnel to establish
-        TIMEOUT=60
-        ELAPSED=0
-        
-        while [ $ELAPSED -lt $TIMEOUT ]; do
-          if [ -f browserstack-local.log ] && grep -q "You can now access your local server(s) in our remote browser" browserstack-local.log; then
-            echo "BrowserStack Local tunnel established"
-            exit 0
-          fi
-          if [ -f browserstack-local.log ] && grep -q -i "error\|failed\|unable" browserstack-local.log; then
-            echo "BrowserStack Local tunnel failed:"
-            cat browserstack-local.log
-            exit 1
-          fi
-          sleep 5
-          ELAPSED=$((ELAPSED + 5))
-        done
-        
-        echo "BrowserStack Local tunnel timeout after ${TIMEOUT}s"
-        [ -f browserstack-local.log ] && cat browserstack-local.log
-        exit 1
+    - name: BrowserStackLocal Setup
+      uses: 'browserstack/github-actions/setup-local@master'
+      with:
+        local-testing: start
+        local-identifier: random
     
     - name: Create BrowserStack config
       working-directory: java-spring
@@ -241,9 +221,11 @@ jobs:
           rm app.pid
         fi
     
-    - name: Stop BrowserStack Local tunnel
+    - name: BrowserStackLocal Stop
       if: always()
-      run: pkill -f "BrowserStackLocal" || true
+      uses: 'browserstack/github-actions/setup-local@master'
+      with:
+        local-testing: stop
     
     - name: Upload test reports
       if: always()
@@ -258,9 +240,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: spring-boot-logs-${{ github.run_number }}
-        path: |
-          java-spring/app.log
-          browserstack-local.log
+        path: java-spring/app.log
         retention-days: 1
 
   summary:


### PR DESCRIPTION
## Summary

Refactors the Java Spring CI workflow to use official BrowserStack GitHub Actions instead of manually managing BrowserStackLocal.

## Changes

### Before
- Manual download and installation of BrowserStackLocal binary
- Custom tunnel startup logic with timeout handling
- Manual tunnel shutdown with `pkill`
- ~40 lines of boilerplate code

### After
- Use `browserstack/github-actions/setup-env@master` for credentials
- Use `browserstack/github-actions/setup-local@master` for tunnel lifecycle
- ~17 lines of clean, declarative configuration
- 20 fewer lines of code

## Benefits

✅ **Cleaner workflow** - Less boilerplate, more readable
✅ **Official actions** - Maintained by BrowserStack team  
✅ **Cross-platform** - Automatic binary selection for runner OS
✅ **Better error handling** - Built into the actions
✅ **Easier maintenance** - No manual tunnel management code

## Testing

The workflow will run automatically on push. The Java Spring tests should continue to work identically, just with BrowserStack GHA managing the tunnel.

## Stack

This PR builds on top of #181 which adds inline seed steps and Step Summaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)