### PR TITLE
fix: add concurrency group to avoid limits

### DIFF
--- a/.github/workflows/android-cpp-ci.yml
+++ b/.github/workflows/android-cpp-ci.yml
@@ -136,7 +136,9 @@ jobs:
     needs: build
     if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 45
-    
+    concurrency:
+      group: browserstack-testing
+      cancel-in-progress: false
     steps:
     - uses: actions/checkout@v4
     

--- a/.github/workflows/android-java-ci.yml
+++ b/.github/workflows/android-java-ci.yml
@@ -111,6 +111,9 @@ jobs:
     needs: build
     if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 45
+    concurrency:
+      group: browserstack-testing
+      cancel-in-progress: false
     
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/android-kotlin-ci.yml
+++ b/.github/workflows/android-kotlin-ci.yml
@@ -145,6 +145,9 @@ jobs:
     needs: build-and-test
     if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 45
+    concurrency:
+      group: browserstack-testing
+      cancel-in-progress: false
     
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/dotnet-maui-ci.yml
+++ b/.github/workflows/dotnet-maui-ci.yml
@@ -214,6 +214,9 @@ jobs:
     needs: [build-android, seed-task-data]
     timeout-minutes: 30
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    concurrency:
+      group: browserstack-testing
+      cancel-in-progress: false
 
     steps:
       - name: Checkout code
@@ -275,6 +278,9 @@ jobs:
     needs: [build-ios, seed-task-data]
     timeout-minutes: 60
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    concurrency:
+      group: browserstack-testing
+      cancel-in-progress: false
 
     steps:
       - name: Checkout code

--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -436,6 +436,9 @@ jobs:
     needs: [build-android, seed-data]
     if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 45
+    concurrency:
+      group: browserstack-testing
+      cancel-in-progress: false
     outputs:
       build_id: ${{ steps.test.outputs.build_id }}
 
@@ -677,6 +680,9 @@ jobs:
     needs: [build-ios, seed-data]
     if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 45
+    concurrency:
+      group: browserstack-testing
+      cancel-in-progress: false
 
     steps:
       - name: Checkout code

--- a/.github/workflows/kotlin-multiplatform-ci.yml
+++ b/.github/workflows/kotlin-multiplatform-ci.yml
@@ -338,6 +338,9 @@ jobs:
     needs: build-android
     if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 45
+    concurrency:
+      group: browserstack-testing
+      cancel-in-progress: false
     
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/react-native-ci.yml
+++ b/.github/workflows/react-native-ci.yml
@@ -268,6 +268,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-android, seed-ditto-cloud]
     timeout-minutes: 30
+    concurrency:
+      group: browserstack-testing
+      cancel-in-progress: false
     outputs:
       build_id: ${{ steps.execute-tests.outputs.build_id }}
       status: ${{ job.status }}

--- a/.github/workflows/react-native-expo-ci.yml
+++ b/.github/workflows/react-native-expo-ci.yml
@@ -272,6 +272,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-android, seed-ditto-cloud]
     timeout-minutes: 30
+    concurrency:
+      group: browserstack-testing
+      cancel-in-progress: false
     outputs:
       build_id: ${{ steps.execute-tests.outputs.build_id }}
       status: ${{ job.status }}

--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -217,6 +217,9 @@ jobs:
     needs: [build-ios]
     if: needs.build-ios.outputs.ios-build-success == 'true'
     timeout-minutes: 60
+    concurrency:
+      group: browserstack-testing
+      cancel-in-progress: false
     
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This PR adds concurrency groups to all browserstack test jobs. The goal is to avoid hitting the concurrency limits for testing during CI.