### PR TITLE
security: patch node-forge 1.3.3 → 1.4.0 (CVE-2026-33891, CVE-2026-33894, CVE-2026-33895, CVE-2026-33896)

### DIFF
--- a/javascript-tui/package-lock.json
+++ b/javascript-tui/package-lock.json
@@ -10225,9 +10225,9 @@
 			"peer": true
 		},
 		"node_modules/node-forge": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-			"integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+			"integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
 			"license": "(BSD-3-Clause OR GPL-2.0)",
 			"peer": true,
 			"engines": {

--- a/javascript-web/package-lock.json
+++ b/javascript-web/package-lock.json
@@ -9363,9 +9363,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "peer": true,
       "engines": {

--- a/react-native-expo/package-lock.json
+++ b/react-native-expo/package-lock.json
@@ -13120,9 +13120,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"

--- a/react-native-expo/yarn.lock
+++ b/react-native-expo/yarn.lock
@@ -6719,9 +6719,9 @@ node-fetch@^2.7.0:
     whatwg-url "^5.0.0"
 
 node-forge@^1.2.1, node-forge@^1.3.1:
-  version "1.3.3"
-  resolved "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz"
-  integrity sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz"
+  integrity sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
## Summary

Patches all node-forge instances across the repo to fix four CVEs:

- **CVE-2026-33891**: DoS via infinite loop in BigInteger.modInverse() with zero input
- **CVE-2026-33894**: Signature forgery in RSA-PKCS due to ASN.1 extra field
- **CVE-2026-33895**: Signature forgery in Ed25519 due to missing S > L check
- **CVE-2026-33896**: basicConstraints bypass in certificate chain verification (RFC 5280 violation)

All fixed by bumping `node-forge` 1.3.3 → 1.4.0.

### Manifests patched

| Manifest | Alerts |
|----------|--------|
| `javascript-tui/package-lock.json` | [#295](https://github.com/getditto/quickstart/security/dependabot/295), [#299](https://github.com/getditto/quickstart/security/dependabot/299), [#303](https://github.com/getditto/quickstart/security/dependabot/303), [#307](https://github.com/getditto/quickstart/security/dependabot/307) |
| `javascript-web/package-lock.json` | [#296](https://github.com/getditto/quickstart/security/dependabot/296), [#300](https://github.com/getditto/quickstart/security/dependabot/300), [#304](https://github.com/getditto/quickstart/security/dependabot/304), [#308](https://github.com/getditto/quickstart/security/dependabot/308) |
| `react-native-expo/package-lock.json` | [#297](https://github.com/getditto/quickstart/security/dependabot/297), [#301](https://github.com/getditto/quickstart/security/dependabot/301), [#305](https://github.com/getditto/quickstart/security/dependabot/305), [#309](https://github.com/getditto/quickstart/security/dependabot/309) |
| `react-native-expo/yarn.lock` | [#298](https://github.com/getditto/quickstart/security/dependabot/298), [#302](https://github.com/getditto/quickstart/security/dependabot/302), [#306](https://github.com/getditto/quickstart/security/dependabot/306), [#310](https://github.com/getditto/quickstart/security/dependabot/310) |

## Resolves

Closes SPO-357, SPO-358, SPO-359, SPO-360, SPO-361, SPO-362, SPO-363, SPO-364, SPO-365, SPO-366, SPO-367, SPO-368, SPO-369, SPO-370, SPO-371, SPO-372

- [SPO-357](https://linear.app/ditto/issue/SPO-357/high-forge-has-denial-of-service-via-infinite-loop-in)
- [SPO-358](https://linear.app/ditto/issue/SPO-358/high-forge-has-denial-of-service-via-infinite-loop-in)
- [SPO-359](https://linear.app/ditto/issue/SPO-359/high-forge-has-denial-of-service-via-infinite-loop-in)
- [SPO-360](https://linear.app/ditto/issue/SPO-360/high-forge-has-denial-of-service-via-infinite-loop-in)
- [SPO-361](https://linear.app/ditto/issue/SPO-361/high-forge-has-signature-forgery-in-rsa-pkcs-due-to-asn1-extra-field)
- [SPO-362](https://linear.app/ditto/issue/SPO-362/high-forge-has-signature-forgery-in-rsa-pkcs-due-to-asn1-extra-field)
- [SPO-363](https://linear.app/ditto/issue/SPO-363/high-forge-has-signature-forgery-in-rsa-pkcs-due-to-asn1-extra-field)
- [SPO-364](https://linear.app/ditto/issue/SPO-364/high-forge-has-signature-forgery-in-rsa-pkcs-due-to-asn1-extra-field)
- [SPO-365](https://linear.app/ditto/issue/SPO-365/high-forge-has-signature-forgery-in-ed25519-due-to-missing-s-l-check)
- [SPO-366](https://linear.app/ditto/issue/SPO-366/high-forge-has-signature-forgery-in-ed25519-due-to-missing-s-l-check)
- [SPO-367](https://linear.app/ditto/issue/SPO-367/high-forge-has-signature-forgery-in-ed25519-due-to-missing-s-l-check)
- [SPO-368](https://linear.app/ditto/issue/SPO-368/high-forge-has-a-basicconstraints-bypass-in-its-certificate-chain)
- [SPO-369](https://linear.app/ditto/issue/SPO-369/high-forge-has-a-basicconstraints-bypass-in-its-certificate-chain)
- [SPO-370](https://linear.app/ditto/issue/SPO-370/high-forge-has-a-basicconstraints-bypass-in-its-certificate-chain)
- [SPO-371](https://linear.app/ditto/issue/SPO-371/high-forge-has-signature-forgery-in-ed25519-due-to-missing-s-l-check)
- [SPO-372](https://linear.app/ditto/issue/SPO-372/high-forge-has-a-basicconstraints-bypass-in-its-certificate-chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)