### PR TITLE
Migrate ditto.live links to ditto.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ programming languages and platforms.
 See Ditto's [Quickstarts](https://docs.ditto.live/sdk/latest/quickstarts/quickstarts-landing)
 documentation for more information.
 
-For support, please contact Ditto Support (<support@ditto.live>).
+For support, please contact Ditto Support (<support@ditto.com>).
 
 ## Obtaining your Ditto Identity
 

--- a/flutter_app/README.md
+++ b/flutter_app/README.md
@@ -115,7 +115,7 @@ Explore the following links and resources to learn more about Ditto:
 
 #### General Information
 
-- [Ditto Home Page](https://ditto.live)
+- [Ditto Home Page](https://www.ditto.com)
 - [Ditto Documentation Site](https://docs.ditto.live)
 - [Ditto Flutter Install Guide](https://docs.ditto.live/flutter/installation)
 - [Ditto Flutter Quick Start](https://docs.ditto.live/flutter/installation)

--- a/react-native/README.md
+++ b/react-native/README.md
@@ -95,4 +95,4 @@ Should you encounter any issues, please refer to the [Ditto documentation](https
 
 ### Contact
 
-For support or queries, reach out to us via [support@ditto.live](mailto:support@ditto.live).
+For support or queries, reach out to us via [support@ditto.com](mailto:support@ditto.com).


### PR DESCRIPTION
## Summary
- Updates README support contact (root and `react-native/`) from `support@ditto.live` to `support@ditto.com`.
- Updates Ditto Home Page link in `flutter_app/README.md` from `https://ditto.live` to `https://www.ditto.com`.