### PR TITLE
fix(react-native): disable fmt consteval for Xcode 26.4 builds

### DIFF
--- a/react-native/ios/Podfile
+++ b/react-native/ios/Podfile
@@ -31,5 +31,20 @@ target 'DittoReactNativeSampleApp' do
       :mac_catalyst_enabled => false,
       # :ccache_enabled => true
     )
+
+    # Workaround for fmt 11.x consteval incompatibility with Xcode 26.4 clang.
+    # Compile the fmt pod as C++17 so __cpp_consteval is not defined, which
+    # forces fmt to skip the consteval FMT_STRING code path entirely and fall
+    # back to runtime format-string validation. Scoped to the fmt target only —
+    # RCT-Folly, React-Core, and the rest of RN keep their C++20 settings.
+    # See: https://github.com/fmtlib/fmt/issues/4740 and SDKS-3242.
+    # Remove when React Native upgrades to a build that bundles fmt >= 11.1.
+    installer.pods_project.targets.each do |target|
+      if target.name == 'fmt'
+        target.build_configurations.each do |cfg|
+          cfg.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++17'
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Apply the fmt-consteval Xcode 26.4 fix to the React Native quickstart's `Podfile`.

Without this, `react-native run-ios` (Debug or Release) on Xcode 26.4 fails to compile the bundled `fmt` 11.0.2 Pod with:

```
error: call to consteval function 'fmt::basic_format_string<...>' is not a constant expression
```

The post_install hook compiles only the `fmt` target as C++17 so `__cpp_consteval` isn't defined, which causes fmt to skip its consteval `FMT_STRING` path and fall back to runtime format-string validation. RCT-Folly, React-Core, and the rest of RN keep their C++20 settings.

This mirrors the fix the SDK team landed in the monorepo's example app:

- getditto/ditto#22248 (main, v5)
- getditto/ditto#22327 (cherry-pick to `releases/stable/sdk-4.14`)

Confirmed locally on Xcode 26.4: with the snippet in place, `react-native run-ios --device 'KJ iPhone XR' --mode Release` builds, installs, and launches successfully. Without it, the same command fails on the consteval errors above.

Remove this hook once React Native bundles `fmt >= 11.1` (which has the upstream consteval fix).

## Linear

Closes SDKS-3595

## Test plan

- [ ] `cd react-native/ios && pod install` succeeds
- [ ] `cd react-native && npx react-native run-ios --simulator 'iPhone 16'` builds clean (no consteval errors)
- [ ] CI passes for the React Native iOS build
