### PR TITLE
SPO-479: Port getditto/ditto automated security patch action to getditto/quickstarts

### DIFF
--- a/.github/workflows/security-update-claude.yml
+++ b/.github/workflows/security-update-claude.yml
@@ -1,0 +1,48 @@
+# Per-repo caller workflow for automated security patching.
+# The reusable workflow lives in getditto/sec-tools-public.
+
+name: Security Update
+
+on:
+  workflow_dispatch:
+    inputs:
+      ecosystem:
+        description: "Package ecosystem (npm, cargo, docker, go, python)"
+        required: true
+        type: choice
+        options:
+          - npm
+          - cargo
+          - docker
+          - go
+          - python
+      alerts:
+        description: "JSON array of {package, version, cve, manifest}"
+        required: true
+        type: string
+      linear_tickets:
+        description: "Comma-separated Linear ticket IDs"
+        required: false
+        type: string
+      batch_id:
+        description: "Unique batch identifier"
+        required: true
+        type: string
+      reviewers:
+        description: "Comma-separated GitHub teams/users to request review from"
+        required: false
+        type: string
+        default: "security-team,copilot"
+
+jobs:
+  fix:
+    uses: getditto/sec-tools-public/.github/workflows/security-update-claude.yml@main
+    with:
+      ecosystem: ${{ inputs.ecosystem }}
+      alerts: ${{ inputs.alerts }}
+      linear_tickets: ${{ inputs.linear_tickets }}
+      batch_id: ${{ inputs.batch_id }}
+      reviewers: ${{ inputs.reviewers }}
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GH_TOKEN_SECURITY_PATCHES: ${{ secrets.GH_TOKEN_SECURITY_PATCHES }}

--- a/.github/workflows/security-update-claude.yml
+++ b/.github/workflows/security-update-claude.yml
@@ -33,7 +33,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  fix:
+  forward-to-sec-tools-public:
     uses: getditto/sec-tools-public/.github/workflows/security-update-claude.yml@main
     with:
       ecosystem: ${{ inputs.ecosystem }}

--- a/.github/workflows/security-update-claude.yml
+++ b/.github/workflows/security-update-claude.yml
@@ -28,6 +28,10 @@ on:
         type: string
         default: "security-team,copilot"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   fix:
     uses: getditto/sec-tools-public/.github/workflows/security-update-claude.yml@main

--- a/.github/workflows/security-update-claude.yml
+++ b/.github/workflows/security-update-claude.yml
@@ -1,7 +1,7 @@
 # Per-repo caller workflow for automated security patching.
 # The reusable workflow lives in getditto/sec-tools-public.
 
-name: Security Update
+name: 'Security Dependency Update (Claude Code)'
 
 on:
   workflow_dispatch:

--- a/.github/workflows/security-update-claude.yml
+++ b/.github/workflows/security-update-claude.yml
@@ -9,13 +9,7 @@ on:
       ecosystem:
         description: "Package ecosystem (npm, cargo, docker, go, python)"
         required: true
-        type: choice
-        options:
-          - npm
-          - cargo
-          - docker
-          - go
-          - python
+        type: string
       alerts:
         description: "JSON array of {package, version, cve, manifest}"
         required: true


### PR DESCRIPTION
## SPO-479: Port security patch automation to quickstart

[SPO-479](https://linear.app/ditto/issue/SPO-479)

## Summary

- Adds `.github/workflows/security-update-claude.yml` — a thin caller workflow for Tines-driven automated security patching
- The reusable workflow (Claude prompt, PR creation logic) lives in [`getditto/sec-tools-public`](https://github.com/getditto/sec-tools-public); this file just forwards inputs and secrets
- Named `security-update-claude.yml` to match what Tines dispatches

## Prerequisites

- [x] `ANTHROPIC_API_KEY` secret provisioned
- [ ] `GH_TOKEN_SECURITY_PATCHES` secret provisioned (IT pending)
- [ ] SPO-893 merged in sec-tools-public (reusable workflow uses `workflow_call`)

## Test plan

- [ ] After prerequisites met, trigger a manual workflow dispatch with a test payload
- [ ] Verify a fix PR is opened on this repo by the bot identity
- [ ] Verify CI runs on the generated PR