### PR TITLE
Update rust-tui so "cargo run" will not output in terminal

### DIFF
--- a/rust-tui/Cargo.toml
+++ b/rust-tui/Cargo.toml
@@ -29,6 +29,7 @@ dotenvy = "0.15.7"
 futures = "0.3.31"
 futures-concurrency = "7.6"
 hashbrown = "0.15.2"
+libc = "0.2"
 ratatui = { version = "0.29", features = ["crossterm"] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"

--- a/rust-tui/README.md
+++ b/rust-tui/README.md
@@ -35,10 +35,6 @@ export DITTO_WEBSOCKET_URL = "";
 Next, run the quickstart app with the following command:
 
 ```
-cargo run 2>/dev/null
+cargo run
 ```
-
-> NOTE: The `2>/dev/null` is a workaround to silence output on `stderr`, since
-> that would interfere with the TUI application. Without it, the screen will
-> quickly become garbled.
 

--- a/rust-tui/src/bin/main.rs
+++ b/rust-tui/src/bin/main.rs
@@ -44,6 +44,22 @@ impl Cli {
             .append(true)
             .open(&self.log)
             .with_context(|| format!("failed to open logfile {}", self.log.display()))?;
+
+        // The Ditto SDK's C internals write directly to fd 2, bypassing Rust's
+        // tracing system. Redirect stderr to the log file so those writes don't
+        // corrupt the TUI. Only redirect when stderr is a terminal; if the
+        // caller has already redirected stderr (e.g. `cargo run 2>file`), we
+        // leave it alone.
+        #[cfg(unix)]
+        {
+            use std::os::unix::io::AsRawFd;
+            unsafe {
+                if libc::isatty(libc::STDERR_FILENO) == 1 {
+                    libc::dup2(logfile.as_raw_fd(), libc::STDERR_FILENO);
+                }
+            }
+        }
+
         tracing_subscriber::registry()
             .with(tracing_subscriber::fmt::layer().with_writer(logfile))
             .try_init()?;

--- a/rust-tui/src/bin/main.rs
+++ b/rust-tui/src/bin/main.rs
@@ -47,8 +47,8 @@ impl Cli {
 
         // The Ditto SDK's C internals write directly to fd 2, bypassing Rust's
         // tracing system. Redirect stderr to the log file so those writes don't
-        // corrupt the TUI. Only redirect when stderr is a terminal; if the
-        // caller has already redirected stderr (e.g. `cargo run 2>file`), we
+        // corrupt the TUI. Only redirect when stderr is currently a terminal;
+        // if stderr is already non-terminal (for example, `cargo run 2>file`),
         // leave it alone.
         #[cfg(unix)]
         {


### PR DESCRIPTION
Hey! I am interviewing for a Product Manager - Networking job at Ditto. I was using your SDK to try out your product.

I wanted to submit a PR for a small quality of life improvement in the rust-tui app

- I made an adjustment in main.rs so that "cargo run" won't output stderr into the terminal by default
- Any stderr output is redirect to the log file unless the user redirected the output to somewhere else
- Added libc as a dependency

Let me know what you think.