### PR TITLE
Drop redundant transport config from java-server quickstart

### DIFF
--- a/java-server/src/main/java/com/ditto/example/spring/quickstart/service/DittoService.java
+++ b/java-server/src/main/java/com/ditto/example/spring/quickstart/service/DittoService.java
@@ -62,19 +62,6 @@ public class DittoService implements DisposableBean {
 
         this.ditto.setDeviceName("Java");
 
-        this.ditto.updateTransportConfig(config -> {
-            config.connect(connect -> {
-                // Set the Ditto Websocket URL
-                connect.websocketUrls().add(DittoSecretsConfiguration.DITTO_WEBSOCKET_URL);
-            });
-            config.peerToPeer(p2p -> {
-                p2p.bluetoothLe().isEnabled(true);
-                p2p.lan().isEnabled(true);
-            });
-
-            logger.info("Transport config: {}", config);
-        });
-
         presenceObserver = observePeersPresence();
 
         syncStateObserver = setupAndObserveSyncState();


### PR DESCRIPTION
v5's `serverConnect(endpoint)` already wires the cloud-sync transport from the URL it's given, so the `connect().websocketUrls().add(...)` block is v4 leftover. The `peerToPeer()` block re-enables BLE and LAN, which v5 turns on by default, and BLE has no business on a server peer anyway.

Canonical v5 init doesn't include `updateTransportConfig` at all: https://docs.ditto.live/sdk/latest/install-guides/java/server

Leaving `DITTO_WEBSOCKET_URL` in `.env.sample` since other quickstarts still reference it. Cross-app audit to follow.