### PR TITLE
fix(flutter): parameterize task UPDATE statements to close DQL injection risk

### DIFF
--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -194,7 +194,8 @@ class _DittoExampleState extends State<DittoExample> {
           // Use the Soft-Delete pattern
           // https://docs.ditto.live/sdk/latest/crud/delete#soft-delete-pattern
           await _ditto!.store.execute(
-            "UPDATE tasks SET deleted = true WHERE _id = '${task.id}'",
+            "UPDATE tasks SET deleted = true WHERE _id = :id",
+            arguments: {"id": task.id},
           );
 
           if (mounted) {
@@ -209,7 +210,8 @@ class _DittoExampleState extends State<DittoExample> {
           title: Text(task.title),
           value: task.done,
           onChanged: (value) => _ditto!.store.execute(
-            "UPDATE tasks SET done = $value WHERE _id = '${task.id}'",
+            "UPDATE tasks SET done = :done WHERE _id = :id",
+            arguments: {"id": task.id, "done": value},
           ),
           secondary: IconButton(
             icon: const Icon(Icons.edit),
@@ -220,7 +222,8 @@ class _DittoExampleState extends State<DittoExample> {
 
               // https://docs.ditto.live/sdk/latest/crud/update
               _ditto!.store.execute(
-                "UPDATE tasks SET title = '${newTask.title}' where _id = '${task.id}'",
+                "UPDATE tasks SET title = :title WHERE _id = :id",
+                arguments: {"id": task.id, "title": newTask.title},
               );
             },
           ),

--- a/flutter_app/test/dql_safety_test.dart
+++ b/flutter_app/test/dql_safety_test.dart
@@ -1,0 +1,71 @@
+// Regression test for the parameterized-DQL fix.
+//
+// Earlier versions of this file built UPDATE statements by interpolating
+// user-typed task titles into DQL strings, e.g.:
+//
+//   "UPDATE tasks SET title = '${newTask.title}' where _id = '${task.id}'"
+//
+// A task titled `'); EVICT FROM tasks WHERE true; --` could break out of
+// the quoted value and run arbitrary DQL. The fix switched to named
+// parameter binding (`:title`, `:done`, `:id`) with values passed via the
+// `arguments:` map.
+//
+// This test pins the fix as a static-source check: any future change that
+// reintroduces Dart string interpolation into the DQL strings in
+// `lib/main.dart` fails here loudly. It does not exercise the DQL engine —
+// a real round-trip test would need a live `Ditto` instance, which lives in
+// `integration_test/`. The check is intentionally coarse and operates on
+// the file as text.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('main.dart DQL safety', () {
+    late String source;
+
+    setUpAll(() {
+      source = File('lib/main.dart').readAsStringSync();
+    });
+
+    test('uses named parameter binding for every mutable field', () {
+      expect(source, contains(':task'), reason: 'INSERT binding missing');
+      expect(source, contains(':title'), reason: 'updateTitle binding missing');
+      expect(source, contains(':done'), reason: 'setDone binding missing');
+      expect(source, contains(':id'),
+          reason: 'WHERE _id = :id binding missing');
+    });
+
+    test('no Dart string interpolation inside DQL execute() calls', () {
+      // Find every `_ditto!.store.execute(` (or `.execute(`) call site and
+      // inspect the string literal that follows up to the next `,` or `)`.
+      // Forbid `${` and `$identifier` inside those literals.
+      final calls = RegExp(r'\.execute\(\s*"([^"]*)"').allMatches(source);
+      expect(
+        calls.isNotEmpty,
+        isTrue,
+        reason: 'No execute() calls found — has main.dart moved?',
+      );
+
+      final shortInterp = RegExp(r'\$[a-zA-Z_{][a-zA-Z0-9_]*');
+      for (final m in calls) {
+        final query = m.group(1)!;
+        expect(
+          query,
+          isNot(contains(r'${')),
+          reason: 'Found `\${` inside DQL: $query — use named binding.',
+        );
+        final hit = shortInterp.firstMatch(query);
+        expect(
+          hit,
+          isNull,
+          reason: hit == null
+              ? ''
+              : 'Found `${hit.group(0)}` (Dart interpolation) inside DQL: '
+                  '$query — replace with `:name` and pass via `arguments:`.',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary

The Flutter Tasks quickstart's three `UPDATE` statements built DQL by interpolating user-typed task titles into the query string:

```dart
// before
"UPDATE tasks SET title = '${newTask.title}' where _id = '${task.id}'"
"UPDATE tasks SET done = $value WHERE _id = '${task.id}'"
"UPDATE tasks SET deleted = true WHERE _id = '${task.id}'"
```

A task titled `'); EVICT FROM tasks WHERE true; --` could break out of the quoted value and run arbitrary DQL. Switches all three to named parameter binding (`:title`, `:done`, `:id`) with values passed via the `arguments:` map — the same pattern `INSERT` already uses two lines up.

```dart
// after
"UPDATE tasks SET title = :title WHERE _id = :id", arguments: {"id": task.id, "title": newTask.title}
"UPDATE tasks SET done = :done WHERE _id = :id", arguments: {"id": task.id, "done": value}
"UPDATE tasks SET deleted = true WHERE _id = :id", arguments: {"id": task.id}
```

## Regression pin

Also adds `test/dql_safety_test.dart` — a static-source check that reads `lib/main.dart` as text and asserts every `execute(...)` call's first string argument is interpolation-free, and that every mutable field has a named binding (`:task`, `:title`, `:done`, `:id`). If a future change reintroduces `${var}` or `$identifier` into a DQL string, the test fails loudly.

The test is intentionally coarse — it doesn't exercise the DQL engine. A real round-trip test would need a live `Ditto` instance, which lives in `integration_test/`.

## Why this PR (and not the larger refactor)

This fix is also present in [#286](https://github.com/getditto/quickstart/pull/286) (the architecture refactor experiment), but that PR is large, in draft, and gated on team discussion of multiple design questions. The security improvement shouldn't wait on the refactor's fate, so this is the smallest possible cherry-pick: 3 line edits + one test file. No structural changes, no public API changes.

## Validation

- `flutter analyze` — clean except for the pre-existing `.env` asset warning
- `flutter test` — 3/3 pass (2 new DQL safety tests + 1 pre-existing widget smoke test)
- `dart format` — clean

## AI assistance

AI-assisted with thorough supervision — Claude drafted the fix and the regression test under direction; human (@alyssa-evans) reviewed the parameterization shape and is reviewing the diff before flipping out of draft.

## Test plan

- [ ] Reviewer confirms the parameterized-DQL shape against the `ditto_live` SDK docs (specifically that `:name` bindings work for `UPDATE ... SET col = :name` not just `WHERE col = :name`)
- [ ] Manual smoke test: edit a task title to include `'); EVICT FROM tasks WHERE true; --` and confirm it persists as a literal title without firing the EVICT
- [ ] Run `integration_test/app_test.dart` against device with real `.env` credentials before flipping out of draft