### PR TITLE
Update java-server to Ditto SDK 5.0.0 GA

### DIFF
--- a/java-server/README.md
+++ b/java-server/README.md
@@ -16,5 +16,5 @@ For more information, see - [Java Install Guide](https://docs.ditto.live/sdk/lat
 ## Additional Resources
 
 - [Java Roadmap and Support Policy](https://docs.ditto.live/sdk/latest/install-guides/java/roadmap)
-- [API Reference](https://software.ditto.live/java/ditto-java/4.11.0-preview.1/api-reference/)
+- [API Reference](https://software.ditto.live/java/ditto-java/5.0.0/api-reference/)
 

--- a/java-server/build.gradle.kts
+++ b/java-server/build.gradle.kts
@@ -31,29 +31,29 @@ spotbugs {
 
 dependencies {
     // ditto-java artifact includes the Java API for Ditto
-    implementation("com.ditto:ditto-java:5.0.0-java")
+    implementation("com.ditto:ditto-java:5.0.0")
 
     // This will include binaries for all the supported platforms and architectures
-    implementation("com.ditto:ditto-binaries:5.0.0-java")
+    implementation("com.ditto:ditto-binaries:5.0.0")
 
     // To reduce your module artifact's size, consider including just the necessary platforms and architectures
     /*
         // macOS Apple Silicon
-        implementation("com.ditto:ditto-binaries:5.0.0-java") {
+        implementation("com.ditto:ditto-binaries:5.0.0") {
             capabilities {
                 requireCapability("com.ditto:ditto-binaries-macos-arm64")
             }
         }
 
         // Windows x86_64
-        implementation("com.ditto:ditto-binaries:5.0.0-java") {
+        implementation("com.ditto:ditto-binaries:5.0.0") {
             capabilities {
                 requireCapability("com.ditto:ditto-binaries-windows-x64")
             }
         }
 
         // Linux x86_64
-        implementation("com.ditto:ditto-binaries:5.0.0-java") {
+        implementation("com.ditto:ditto-binaries:5.0.0") {
             capabilities {
                 requireCapability("com.ditto:ditto-binaries-linux-x64")
             }

--- a/java-server/src/main/java/com/ditto/example/spring/quickstart/service/DittoService.java
+++ b/java-server/src/main/java/com/ditto/example/spring/quickstart/service/DittoService.java
@@ -16,7 +16,6 @@ import reactor.core.publisher.Sinks;
 
 import java.io.File;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
 
 @Component
 public class DittoService implements DisposableBean {
@@ -117,7 +116,7 @@ public class DittoService implements DisposableBean {
 
     private DittoStoreObserver setupAndObserveSyncState() {
         try {
-            boolean hasNoSyncState = ditto.getStore().execute(
+            boolean hasNoSyncState = ditto.getStore().executeRaw(
                     "SELECT * FROM %s".formatted(DITTO_SYNC_STATE_COLLECTION)
             ).toCompletableFuture().join().getItems().isEmpty();
             if (hasNoSyncState) {
@@ -153,12 +152,12 @@ public class DittoService implements DisposableBean {
 
                         if (newSyncState) {
                             try {
-                                ditto.startSync();
+                                ditto.getSync().start();
                             } catch (DittoException e) {
                                 throw new RuntimeException(e);
                             }
                         } else {
-                            ditto.stopSync();
+                            ditto.getSync().stop();
                         }
 
                         mutableSyncStatePublisher.tryEmitNext(newSyncState);
@@ -169,17 +168,11 @@ public class DittoService implements DisposableBean {
     }
 
     private void setSyncStateIntoDittoStore(boolean newState) {
-        CompletionStage<DittoQueryResult> future = ditto.getStore().execute(
+        ditto.getStore().execute(
                 "UPDATE %s SET %s = :syncState".formatted(DITTO_SYNC_STATE_COLLECTION, DITTO_SYNC_STATE_ID),
                 DittoCborSerializable.buildDictionary()
                         .put("syncState", newState)
                         .build()
-        );
-
-        try {
-            future.toCompletableFuture().join().close();
-        } catch (DittoException e) {
-            throw new RuntimeException(e);
-        }
+        ).toCompletableFuture().join();
     }
 }

--- a/java-server/src/main/java/com/ditto/example/spring/quickstart/service/DittoTaskService.java
+++ b/java-server/src/main/java/com/ditto/example/spring/quickstart/service/DittoTaskService.java
@@ -45,7 +45,7 @@ public class DittoTaskService {
 
     public void toggleTaskDone(@Nonnull String taskId) {
         try {
-            DittoQueryResult tasks = dittoService.getDitto().getStore().execute(
+            DittoQueryResult tasks = dittoService.getDitto().getStore().executeRaw(
                     "SELECT * FROM %s WHERE _id = :taskId".formatted(TASKS_COLLECTION_NAME),
                     DittoCborSerializable.Dictionary.buildDictionary()
                             .put("taskId", taskId)


### PR DESCRIPTION
Bumps `com.ditto:ditto-java` and `com.ditto:ditto-binaries` from `5.0.0-java` to `5.0.0` GA.

5.0.0 dropped two convenience surfaces that this app was using:

- `ditto.startSync()` / `ditto.stopSync()` removed — use `ditto.getSync().start()` / `.stop()` instead.
- `DittoStore.execute(...)` now returns `CompletionStage<Void>` (fire-and-forget). For SELECTs that need a `DittoQueryResult`, use `executeRaw(...)`. INSERT/UPDATE call sites that ignored the result are unchanged in behavior.

Also fixes the README API reference link, which still pointed at v4.11.

Verified locally: `./gradlew check` passes (compile + PMD + SpotBugs).