### PR TITLE
Follow redirect when downloading BrowserStack Local binary

### DIFF
--- a/.github/workflows/java-server-ci.yml
+++ b/.github/workflows/java-server-ci.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Install BrowserStack Local binary
         run: |
-          curl -O "https://www.browserstack.com/browserstack-local/BrowserStackLocal-darwin-x64.zip"
+          curl -fL -O "https://www.browserstack.com/browserstack-local/BrowserStackLocal-darwin-x64.zip"
           unzip BrowserStackLocal-darwin-x64.zip
           chmod +x BrowserStackLocal
 


### PR DESCRIPTION
The **Java Server CI** "BrowserStack Device Testing" job fails at the *Install BrowserStack Local binary* step:

```
End-of-central-directory signature not found.  Either this file is not a zipfile...
unzip:  cannot find zipfile directory in one of BrowserStackLocal-darwin-x64.zip ...
##[error]Process completed with exit code 9.
```

## Cause

`https://www.browserstack.com/browserstack-local/BrowserStackLocal-darwin-x64.zip` now returns a **301 redirect** to `https://local-downloads.browserstack.com/BrowserStackLocal-darwin-x64.zip`. The `curl -O` invocation did not pass `-L`, so it saved the 167-byte HTML redirect page instead of the binary, and `unzip` failed.

## Fix

Add `-fL` to the `curl` call:
- `-L` follows the redirect to the real download.
- `-f` makes curl fail on HTTP errors instead of silently saving an error body.

Verified locally that `curl -fL -O <url>` now retrieves the real ~9.8 MB zip archive.