### PR TITLE
Update dotnet-winforms-net48 to Ditto SDK 5.0.1

### DIFF
--- a/dotnet-winforms-net48/App.config
+++ b/dotnet-winforms-net48/App.config
@@ -1,6 +1,18 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.5" newVersion="8.0.0.5" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/dotnet-winforms-net48/README.md
+++ b/dotnet-winforms-net48/README.md
@@ -14,7 +14,7 @@
 ## Documentation
 
 - [Ditto C# .NET SDK Install Guide](https://docs.ditto.live/install-guides/c-sharp)
-- [Ditto C# .NET SDK API Reference](https://software.ditto.live/dotnet/Ditto/4.14.4/api-reference/)
+- [Ditto C# .NET SDK API Reference](https://software.ditto.live/dotnet/Ditto/5.0.1/api-reference/)
 
 
 ## .NET Windows Forms Application 

--- a/dotnet-winforms-net48/README.md
+++ b/dotnet-winforms-net48/README.md
@@ -8,7 +8,7 @@
 
 1. Install the .NET 4.8 SDK from <https://dotnet.microsoft.com/en-us/download/dotnet-framework/net48>
 2. Create an application at <https://portal.ditto.live>. Make note of the app ID and online playground token
-3. Copy the `.env.sample` file at the top level of the quickstart repo to `.env` and add your app ID and online playground token, and place file in the same folder as the solution and csproj file.
+3. Copy `.env.sample` from the repo root into the `dotnet-winforms-net48/` folder, rename the copy to `.env`, and fill in your `DITTO_APP_ID`, `DITTO_PLAYGROUND_TOKEN`, and `DITTO_AUTH_URL` (from <https://portal.ditto.live>). The `.env` file must live next to `Taskapp.WinForms.Net48.csproj` — this app reads its config from the project folder, not the repo root. (`DITTO_WEBSOCKET_URL` is in the sample but unused by this app; leave it blank.)
 
 
 ## Documentation

--- a/dotnet-winforms-net48/Taskapp.WinForms.Net48.csproj
+++ b/dotnet-winforms-net48/Taskapp.WinForms.Net48.csproj
@@ -38,17 +38,17 @@
     <Reference Include="CBOR, Version=4.5.2.0, Culture=neutral, PublicKeyToken=9cd62db60ea5554c, processorArchitecture=MSIL">
       <HintPath>packages\PeterO.Cbor.4.5.2\lib\net40\CBOR.dll</HintPath>
     </Reference>
-    <Reference Include="Ditto, Version=4.14.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ditto.4.14.4\lib\netstandard2.0\Ditto.dll</HintPath>
+    <Reference Include="Ditto, Version=5.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Ditto.5.0.1\lib\netstandard2.0\Ditto.dll</HintPath>
     </Reference>
     <Reference Include="Ditto.Native.Linux, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ditto.Native.Linux.4.14.4\lib\netstandard2.0\Ditto.Native.Linux.dll</HintPath>
+      <HintPath>packages\Ditto.Native.Linux.5.0.1\lib\netstandard2.0\Ditto.Native.Linux.dll</HintPath>
     </Reference>
     <Reference Include="Ditto.Native.MacOS, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ditto.Native.MacOS.4.14.4\lib\netstandard2.0\Ditto.Native.MacOS.dll</HintPath>
+      <HintPath>packages\Ditto.Native.MacOS.5.0.1\lib\netstandard2.0\Ditto.Native.MacOS.dll</HintPath>
     </Reference>
     <Reference Include="Ditto.Native.Win, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ditto.Native.Win.4.14.4\lib\netstandard2.0\Ditto.Native.Win.dll</HintPath>
+      <HintPath>packages\Ditto.Native.Win.5.0.1\lib\netstandard2.0\Ditto.Native.Win.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bcl.HashCode, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.Bcl.HashCode.1.1.1\lib\net461\Microsoft.Bcl.HashCode.dll</HintPath>
@@ -137,7 +137,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="packages\Ditto.Native.Win.4.14.4\runtimes\win-x64\native\dittoffi.dll">
+    <Content Include="packages\Ditto.Native.Win.5.0.1\runtimes\win-x64\native\dittoffi.dll">
       <Link>dittoffi.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/dotnet-winforms-net48/Taskapp.WinForms.Net48.csproj
+++ b/dotnet-winforms-net48/Taskapp.WinForms.Net48.csproj
@@ -50,6 +50,9 @@
     <Reference Include="Ditto.Native.Win, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\Ditto.Native.Win.5.0.1\lib\netstandard2.0\Ditto.Native.Win.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Bcl.HashCode, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.Bcl.HashCode.1.1.1\lib\net461\Microsoft.Bcl.HashCode.dll</HintPath>
     </Reference>
@@ -71,8 +74,20 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encodings.Web, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Text.Encodings.Web.8.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Json, Version=8.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Text.Json.8.0.5\lib\net462\System.Text.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/dotnet-winforms-net48/TasksPeer.cs
+++ b/dotnet-winforms-net48/TasksPeer.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using DittoSDK;
+using DittoSDK.Auth;
+using DittoSDK.Store;
 using Newtonsoft.Json;
 
 /// <summary>
@@ -35,7 +37,6 @@ namespace Taskapp.WinForms.Net48
         {
             var peer = new TasksPeer(appId, playgroundToken, authUrl);
             peer.Authenticate();
-            await peer.DisableStrictMode();
             peer.RegisterSubscription();
             await peer.InsertInitialTasks();
             peer.StartSync();
@@ -105,19 +106,6 @@ namespace Taskapp.WinForms.Net48
             );
 
             _ditto = Ditto.Open(config);
-            // Required on the 4.x SDK to allow DQL usage; not needed in v5.
-            _ditto.DisableSyncWithV3();
-        }
-
-        /// <summary>
-        /// Disables DQL strict mode to simplify queries — lets <c>SELECT *</c> and
-        /// other ad-hoc queries run without pre-declaring a collection schema.
-        /// Strict mode is on by default in the 4.x SDK; the default flips in v5.
-        /// </summary>
-        /// <seealso href="https://docs.ditto.live/dql/strict-mode"/>
-        private async Task DisableStrictMode()
-        {
-            await _ditto.Store.ExecuteAsync("ALTER SYSTEM SET DQL_STRICT_MODE = false");
         }
 
         public void Dispose()

--- a/dotnet-winforms-net48/TasksPeerService.cs
+++ b/dotnet-winforms-net48/TasksPeerService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using DittoSDK;
+using DittoSDK.Store;
 
 namespace Taskapp.WinForms.Net48
 {

--- a/dotnet-winforms-net48/packages.config
+++ b/dotnet-winforms-net48/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Ditto" version="4.14.4" targetFramework="net48" />
-  <package id="Ditto.Native.Linux" version="4.14.4" targetFramework="net48" />
-  <package id="Ditto.Native.MacOS" version="4.14.4" targetFramework="net48" />
-  <package id="Ditto.Native.Win" version="4.14.4" targetFramework="net48" />
+  <package id="Ditto" version="5.0.1" targetFramework="net48" />
+  <package id="Ditto.Native.Linux" version="5.0.1" targetFramework="net48" />
+  <package id="Ditto.Native.MacOS" version="5.0.1" targetFramework="net48" />
+  <package id="Ditto.Native.Win" version="5.0.1" targetFramework="net48" />
   <package id="Microsoft.Bcl.HashCode" version="1.1.1" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net48" />
   <package id="PeterO.Cbor" version="4.5.2" targetFramework="net48" />

--- a/dotnet-winforms-net48/packages.config
+++ b/dotnet-winforms-net48/packages.config
@@ -4,6 +4,7 @@
   <package id="Ditto.Native.Linux" version="5.0.1" targetFramework="net48" />
   <package id="Ditto.Native.MacOS" version="5.0.1" targetFramework="net48" />
   <package id="Ditto.Native.Win" version="5.0.1" targetFramework="net48" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net48" />
   <package id="Microsoft.Bcl.HashCode" version="1.1.1" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net48" />
   <package id="PeterO.Cbor" version="4.5.2" targetFramework="net48" />
@@ -12,5 +13,9 @@
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
   <package id="System.Memory" version="4.5.5" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
+  <package id="System.Text.Encodings.Web" version="8.0.0" targetFramework="net48" />
+  <package id="System.Text.Json" version="8.0.5" targetFramework="net48" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
## Summary
- Bumps `Ditto` + `Ditto.Native.{Win,MacOS,Linux}` from 4.14.4 to 5.0.1.
  5.0.1 is the first 5.x with netstandard2.0 binaries, which is what
  net48 binds against.
- Adds `System.Text.Json` 8.0.5 and its transitive chain. Ditto 5.0.1's
  netstandard2.0 build pulls this in as a new dep, and packages.config
  doesn't auto-resolve transitives.
- README clarification: this app reads `.env` from its own project
  folder, unlike the other .NET quickstarts. Full alignment with
  `../../.env` tracked separately.

Manually verified on Windows 11 Pro + VS 2026.