### PR TITLE
fix(flutter): align Android minSdkVersion with Ditto docs (26 → 24)

### DIFF
--- a/flutter_app/android/app/build.gradle
+++ b/flutter_app/android/app/build.gradle
@@ -38,7 +38,9 @@ android {
         applicationId "com.example.flutter_quickstart"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion 26
+        // Ditto Flutter SDK supports Android 7+ (API 24).
+        // https://docs.ditto.live/sdk/latest/compatibility/flutter
+        minSdkVersion 24
         targetSdkVersion flutter.targetSdkVersion
         versionCode localProperties.getProperty('flutter.versionCode')?.toInteger() ?: 1
         versionName localProperties.getProperty('flutter.versionName') ?: "1.0.0"


### PR DESCRIPTION
## Summary

Follow-up to #237. Lowers `flutter_app/android/app/build.gradle`'s `minSdkVersion` from 26 to 24 to match the documented Ditto Flutter compatibility floor.

- Ditto Flutter SDK supports Android 7+ (API 24), per [docs.ditto.live/sdk/latest/compatibility/flutter](https://docs.ditto.live/sdk/latest/compatibility/flutter)
- The Flutter quickstart was previously set to 26 (Android 8+), unnecessarily excluding Android 7 devices
- Adds a doc comment + link next to the value so the constraint is self-explanatory

This change rode in too late to make the #237 merge. The plugin-subprojects `minSdkVersion >= 24` override from #237 is already on `main` and stays unchanged — it's still needed because Flutter plugins default their `androidTest` minSdk to 23, which trips the manifest merger against `ditto-internal-rustls:5.0.0`.

## Test plan

- [ ] CI: Android build passes (was the failing job in #237)
- [ ] `flutter build apk` produces an APK that installs on an Android 7 (API 24) device or emulator
- [ ] No regression on Android 8+ devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)