### PR TITLE
feat(python): add Python Tasks TUI and ROS 2 quickstarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ build and run them.
 - [Flutter](flutter_quickstart/README.md)
 - [Javascript TUI](javascript-tui/README.md)
 - [Javascript Web](javascript-web/README.md)
+- [Python TUI](python-tui/README.md)
 - [React Native](react-native/README.md)
 - [React Native Expo](react-native-expo/README.md)
 - [Rust TUI](rust-tui/README.md)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ build and run them.
 - [Javascript TUI](javascript-tui/README.md)
 - [Javascript Web](javascript-web/README.md)
 - [Python TUI](python-tui/README.md)
+- [Python ROS 2](python-ros2/README.md)
 - [React Native](react-native/README.md)
 - [React Native Expo](react-native-expo/README.md)
 - [Rust TUI](rust-tui/README.md)

--- a/justfile
+++ b/justfile
@@ -33,3 +33,15 @@ tools: cmdline_tools
     @echo "Installing tools"
     {{cmdline_tools_dir}}/latest/bin/sdkmanager --install 'build-tools;35.0.0'
     {{cmdline_tools_dir}}/latest/bin/sdkmanager --install 'platforms;android-34'
+
+# Sets up a virtual environment and runs the Python TUI quickstart
+python-tui:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    cd python-tui
+    if [[ ! -d .venv ]]; then
+        python3 -m venv .venv
+    fi
+    .venv/bin/python -m pip install -e .
+    .venv/bin/python main.py

--- a/justfile
+++ b/justfile
@@ -45,3 +45,16 @@ python-tui:
     fi
     .venv/bin/python -m pip install -e .
     .venv/bin/python main.py
+
+# Runs a Ditto <-> ROS 2 quickstart demo in simulation (no ROS 2 install needed).
+# demo = talker-listener | teleop | fleet | all
+python-ros2 demo="all":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    cd python-ros2
+    if [[ ! -d .venv ]]; then
+        python3 -m venv .venv
+    fi
+    .venv/bin/python -m pip install -e .
+    .venv/bin/ditto-ros2 {{demo}} --sim

--- a/python-ros2/.env.sample
+++ b/python-ros2/.env.sample
@@ -1,0 +1,3 @@
+# Copy to .env and fill in. Get an offline-only license token from
+# https://portal.ditto.live. It is loaded automatically when you run a demo.
+DITTO_OFFLINE_TOKEN=

--- a/python-ros2/.gitignore
+++ b/python-ros2/.gitignore
@@ -1,0 +1,6 @@
+.venv/
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+.env

--- a/python-ros2/README.md
+++ b/python-ros2/README.md
@@ -1,0 +1,82 @@
+# Ditto ↔ ROS 2 quickstart
+
+Three small, canonical ROS 2 examples that use **Ditto as the shared-state layer
+instead of DDS pub/sub**. ROS 2's pub/sub is transient and lives on a single DDS
+domain; Ditto gives robots a **persistent, CRDT-merged, offline-first** store
+that syncs peer-to-peer over Wi-Fi/LAN/BLE with **no central broker** — so state
+crosses separate ROS graphs and survives dropped links.
+
+Every demo runs with **no ROS 2 installed** via a tiny in-process `rclpy` shim
+(`--sim`); drop `--sim` on a machine with ROS 2 to use real `rclpy` and the
+standard message packages.
+
+## The three demos
+
+| Demo | ROS message / topic | What Ditto adds |
+| ---- | ------------------- | --------------- |
+| **talker / listener** | `std_msgs/String` on `/chatter` | The ROS 2 "hello world," but talker and listener are in **separate ROS graphs** joined only by Ditto — pub/sub across a boundary DDS can't cross. |
+| **teleop** | `geometry_msgs/Twist` on `/cmd_vel` | A control station drives a robot over the mesh; commands **queue and converge** if the link drops — command/control without a broker. |
+| **fleet** | `geometry_msgs/Pose2D` on `/pose` | Every robot writes its pose into a shared `fleet` collection keyed by robot id and observes the whole fleet: a **shared world model** (one live row per robot), not a stream of transient messages. |
+
+The `fleet` demo is the clearest contrast: DDS has no retained "latest value per
+robot," no persistence across disconnects, and no state once a publisher exits —
+the Ditto collection has all three.
+
+## Run it (no ROS 2 needed)
+
+```bash
+# from the quickstart repo root
+just python-ros2 fleet          # or: talker-listener | teleop | all
+
+# or directly
+cd python-ros2
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e .
+export DITTO_OFFLINE_TOKEN="<your-offline-license-token>"   # or put it in .env
+ditto-ros2 all --sim
+ditto-ros2 fleet --sim --robots 4
+```
+
+Get an offline-only license token from the [Ditto Portal](https://portal.ditto.live).
+Without a token the peers can't activate sync; a local `.env` file with
+`DITTO_OFFLINE_TOKEN=...` is loaded automatically.
+
+Expected `fleet` output (abridged):
+
+```
+[fleet] tick 0: robot-1 sees robot-1=0.00,0.00, robot-2=1.00,1.00, robot-3=2.00,2.00
+...
+[fleet] every robot now shares one world model of 3/3 robots
+```
+
+## Run against real ROS 2
+
+`rclpy` and the message packages come from your ROS 2 install (not pip). With
+ROS 2 sourced, omit `--sim` and the demos use real `rclpy` automatically:
+
+```bash
+source /opt/ros/humble/setup.bash
+pip install -e .
+ditto-ros2 teleop            # real rclpy, real geometry_msgs/Twist
+```
+
+A ready-to-run container is in [`docker/`](docker/) (`docker compose -f
+docker/docker-compose.yml up`), which builds `ros:humble` with the SDK installed.
+
+## How it works
+
+- `ditto_ros2/bridge.py` — `DittoRos2Bridge`: maps a ROS topic ↔ a Ditto
+  collection per `Route` (used by talker/listener and teleop).
+- `ditto_ros2/fleet.py` — the shared-world-model demo (upsert-keyed-by-robot +
+  observe), written directly rather than through the streaming bridge.
+- `ditto_ros2/rclpy_shim.py` + `ros_compat.py` — the in-process ROS stand-in and
+  the single switch between it and real `rclpy`.
+- `ditto_ros2/peers.py` — opens offline peers wired into a loopback TCP mesh so
+  a single-process demo genuinely syncs peer-to-peer.
+
+## Test
+
+```bash
+pip install -e . pytest
+DITTO_OFFLINE_TOKEN=<token> pytest -q     # runs each demo in --sim and asserts it synced
+```

--- a/python-ros2/ditto_ros2/__init__.py
+++ b/python-ros2/ditto_ros2/__init__.py
@@ -1,0 +1,14 @@
+"""Canonical ROS 2 examples bridged through Ditto.
+
+Three small demos show Ditto carrying robot state where ROS 2's DDS pub/sub
+can't reach — across separate ROS graphs, offline, with no central broker:
+
+* ``talker_listener`` — the ROS 2 "hello world" (``std_msgs/String`` on
+  ``/chatter``) with the talker and listener in separate graphs, joined only by
+  Ditto.
+* ``teleop`` — a control station drives a robot (``geometry_msgs/Twist`` on
+  ``/cmd_vel``) over the Ditto mesh.
+* ``fleet`` — every robot writes its pose into a shared Ditto collection and
+  observes the whole fleet: a CRDT-merged shared world model instead of
+  transient pub/sub.
+"""

--- a/python-ros2/ditto_ros2/__main__.py
+++ b/python-ros2/ditto_ros2/__main__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from .main import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python-ros2/ditto_ros2/bridge.py
+++ b/python-ros2/ditto_ros2/bridge.py
@@ -1,0 +1,196 @@
+"""The Ditto ↔ ROS 2 topic bridge.
+
+Each :class:`Route` maps a ROS topic to a Ditto collection in one direction:
+
+* ``ros_to_ditto`` — subscribe to the topic and INSERT every message into the
+  collection (keyed by ``robot_id`` + a monotonic sequence). Ditto then syncs it
+  to every other peer in the mesh — over Wi-Fi/BLE/LAN, with no cloud required.
+* ``ditto_to_ros`` — observe the collection and publish newly-arrived documents
+  onto the topic.
+
+Run the bridge on several robots and a topic published on one appears on the
+others, offline, with CRDT conflict resolution — ROS 2 pub/sub carried across
+separate ROS graphs by Ditto. (For *shared current state* keyed per robot rather
+than a stream of messages, see ``fleet.py``.)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import itertools
+from dataclasses import dataclass
+from typing import Any
+
+from ditto import Ditto
+
+from .ros_compat import get_message_type, get_rclpy
+
+# Bound the per-collection "already published to ROS" cache so a long-running
+# bridge doesn't grow memory without limit. Message ids are monotonic, so
+# evicting the oldest entry is safe (a re-published stale command is harmless).
+_PUBLISHED_CACHE_LIMIT = 4096
+
+
+@dataclass(frozen=True)
+class Route:
+    collection: str
+    topic: str
+    message: str  # short message-type name, e.g. "Twist"
+    direction: str  # "ros_to_ditto" | "ditto_to_ros"
+
+
+def serialize(message: Any) -> dict[str, Any]:
+    """Convert a ROS message (real or shim) to a plain dict for Ditto."""
+
+    to_dict = getattr(message, "to_dict", None)
+    if callable(to_dict):
+        result: dict[str, Any] = to_dict()
+        return result
+    from rosidl_runtime_py.convert import message_to_ordereddict
+
+    return dict(message_to_ordereddict(message))
+
+
+def deserialize(message_type: type, value: dict[str, Any]) -> Any:
+    """Rebuild a ROS message (real or shim) from a Ditto document payload."""
+
+    from_dict = getattr(message_type, "from_dict", None)
+    if callable(from_dict):
+        return from_dict(value)
+    from rosidl_runtime_py.set_message import set_message_fields
+
+    message = message_type()
+    set_message_fields(message, value)
+    return message
+
+
+class DittoRos2Bridge:
+    def __init__(
+        self,
+        ditto: Ditto,
+        node: Any,
+        routes: list[Route],
+        *,
+        robot_id: str,
+        sim: bool | None = None,
+    ) -> None:
+        self._ditto = ditto
+        self._node = node
+        self._routes = routes
+        self._robot_id = robot_id
+        self._sim = sim
+        self._seq = itertools.count()
+        self._subscriptions: list[Any] = []
+        self._ros_subscriptions: list[Any] = []
+        self._observers: list[Any] = []
+        self._pumps: list[asyncio.Task[None]] = []
+        self._spin_task: asyncio.Task[None] | None = None
+        # Last payload published to ROS per document id, so the observer only
+        # re-publishes documents that are new or whose value actually changed.
+        self._published: dict[str, Any] = {}
+
+    async def start(self) -> None:
+        loop = asyncio.get_running_loop()
+        for route in self._routes:
+            self._subscriptions.append(
+                self._ditto.sync.register_subscription(f"SELECT * FROM {route.collection}")
+            )
+            if route.direction == "ros_to_ditto":
+                self._wire_ros_to_ditto(route, loop)
+            elif route.direction == "ditto_to_ros":
+                self._wire_ditto_to_ros(route)
+            else:
+                raise ValueError(f"Unknown route direction: {route.direction}")
+        # Spin the ROS node so inbound messages reach subscriptions and outbound
+        # publishes reach local subscribers, the way rclpy.spin() would.
+        self._spin_task = asyncio.create_task(self._spin_ros())
+        self._ditto.sync.start()
+
+    def _wire_ros_to_ditto(self, route: Route, loop: asyncio.AbstractEventLoop) -> None:
+        queue: asyncio.Queue[Any] = asyncio.Queue()
+
+        def on_ros_message(message: Any) -> None:
+            # Called synchronously from rclpy on publish; hand off to the loop.
+            loop.call_soon_threadsafe(queue.put_nowait, message)
+
+        self._ros_subscriptions.append(
+            self._node.create_subscription(
+                get_message_type(route.message, self._sim), route.topic, on_ros_message, 10
+            )
+        )
+        self._pumps.append(asyncio.create_task(self._pump_to_ditto(route, queue)))
+
+    async def _pump_to_ditto(self, route: Route, queue: asyncio.Queue[Any]) -> None:
+        while True:
+            message = await queue.get()
+            payload = serialize(message)
+            document = {
+                "_id": f"{self._robot_id}:{next(self._seq)}",
+                "robot": self._robot_id,
+                "topic": route.topic,
+                "payload": payload,
+            }
+            result = await self._ditto.store.execute(
+                f"INSERT INTO {route.collection} DOCUMENTS (:doc) ON ID CONFLICT DO UPDATE",
+                {"doc": document},
+            )
+            result.close()
+
+    def _wire_ditto_to_ros(self, route: Route) -> None:
+        message_type = get_message_type(route.message, self._sim)
+        publisher = self._node.create_publisher(message_type, route.topic, 10)
+
+        def on_change(result: Any) -> None:
+            try:
+                rows = [dict(item.value) for item in result]
+            finally:
+                result.close()
+            for row in rows:
+                document_id = str(row.get("_id"))
+                payload = row.get("payload")
+                if not isinstance(payload, dict):
+                    continue
+                if self._published.get(document_id) == payload:
+                    continue
+                self._published[document_id] = payload
+                if len(self._published) > _PUBLISHED_CACHE_LIMIT:
+                    del self._published[next(iter(self._published))]
+                publisher.publish(deserialize(message_type, payload))
+
+        self._observers.append(
+            self._ditto.store.register_observer(f"SELECT * FROM {route.collection}", on_change)
+        )
+
+    async def _spin_ros(self) -> None:
+        rclpy = get_rclpy(self._sim)
+        while True:
+            rclpy.spin_once(self._node, timeout_sec=0.0)
+            await asyncio.sleep(0.005)
+
+    async def stop(self) -> None:
+        if self._spin_task is not None:
+            self._spin_task.cancel()
+            try:
+                await self._spin_task
+            except asyncio.CancelledError:
+                pass
+            self._spin_task = None
+        for pump in self._pumps:
+            pump.cancel()
+        for pump in self._pumps:
+            try:
+                await pump
+            except asyncio.CancelledError:
+                pass
+        self._pumps.clear()
+        for observer in self._observers:
+            observer.cancel()
+            observer.close()
+        for ros_subscription in self._ros_subscriptions:
+            self._node.destroy_subscription(ros_subscription)
+        for subscription in self._subscriptions:
+            subscription.cancel()
+            subscription.close()
+        self._observers.clear()
+        self._ros_subscriptions.clear()
+        self._subscriptions.clear()

--- a/python-ros2/ditto_ros2/fleet.py
+++ b/python-ros2/ditto_ros2/fleet.py
@@ -1,0 +1,171 @@
+"""Demo 3 — a fleet sharing a live world model through Ditto.
+
+This is the demo that shows what Ditto adds *over* ROS 2 pub/sub. Each robot
+publishes its ``Pose`` on ``/pose`` (its odometry). Instead of streaming those
+poses as transient messages, each robot **upserts its own current pose into a
+shared ``fleet`` collection, keyed by ``robot_id``**, and **observes the whole
+collection**. The collection is a CRDT-merged, offline-durable shared world
+model: it always holds exactly one current pose per robot, every robot sees
+every other robot, and a robot that drops off and rejoins simply reconverges.
+
+Contrast with DDS pub/sub: there is no retained "latest value per robot", no
+persistence across disconnects, and no state once a publisher goes away. Here
+the shared state *is* the collection.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import math
+import tempfile
+import uuid
+from typing import Any
+
+from ditto import Ditto
+from .peers import offline_token, open_peer
+from .ros_compat import get_message_type, get_rclpy, use_sim
+
+_BASE_PORT = 4121
+
+
+class FleetMember:
+    """One robot: publishes its pose on ``/pose`` and mirrors the shared fleet state."""
+
+    def __init__(self, robot_id: str, peer: Ditto, node: Any, sim: bool) -> None:
+        self.robot_id = robot_id
+        self._peer = peer
+        self._node = node
+        self._sim = sim
+        self._pose_type = get_message_type("Pose", sim)
+        self._pose_pub = node.create_publisher(self._pose_type, "/pose", 10)
+        self._subscription: Any = None
+        self._observer: Any = None
+        self._spin_task: asyncio.Task[None] | None = None
+        self._upserts: set[asyncio.Task[None]] = set()
+        # The shared world as this robot currently sees it: robot_id -> (x, y, theta).
+        self.world: dict[str, tuple[float, float, float]] = {}
+
+    async def start(self) -> None:
+        self._subscription = self._peer.sync.register_subscription("SELECT * FROM fleet")
+        # Ingest this robot's own /pose topic into the shared collection.
+        self._node.create_subscription(self._pose_type, "/pose", self._on_pose, 10)
+        # Observe the whole fleet — every robot's latest pose, synced from peers.
+        self._observer = self._peer.store.register_observer("SELECT * FROM fleet", self._on_fleet)
+        self._spin_task = asyncio.create_task(self._spin())
+        self._peer.sync.start()
+
+    def publish_pose(self, x: float, y: float, theta: float) -> None:
+        pose = self._pose_type()
+        pose.x, pose.y, pose.theta = round(x, 3), round(y, 3), round(theta, 3)
+        self._pose_pub.publish(pose)
+
+    def _on_pose(self, message: Any) -> None:
+        # Runs on the loop (via the spin task). Upsert our current pose, keyed by
+        # robot_id so the collection keeps one live row per robot, not a stream.
+        task = asyncio.create_task(
+            self._upsert(float(message.x), float(message.y), float(message.theta))
+        )
+        self._upserts.add(task)
+        task.add_done_callback(self._upserts.discard)
+
+    async def _upsert(self, x: float, y: float, theta: float) -> None:
+        result = await self._peer.store.execute(
+            "INSERT INTO fleet DOCUMENTS (:doc) ON ID CONFLICT DO UPDATE",
+            {"doc": {"_id": self.robot_id, "robot": self.robot_id, "x": x, "y": y, "theta": theta}},
+        )
+        result.close()
+
+    def _on_fleet(self, result: Any) -> None:
+        try:
+            rows = [dict(item.value) for item in result]
+        finally:
+            result.close()
+        self.world = {
+            str(row["robot"]): (float(row["x"]), float(row["y"]), float(row["theta"]))
+            for row in rows
+            if "robot" in row
+        }
+
+    async def _spin(self) -> None:
+        rclpy = get_rclpy(self._sim)
+        while True:
+            rclpy.spin_once(self._node, timeout_sec=0.0)
+            await asyncio.sleep(0.005)
+
+    async def stop(self) -> None:
+        if self._spin_task is not None:
+            self._spin_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._spin_task
+        for task in list(self._upserts):
+            task.cancel()
+        if self._observer is not None:
+            self._observer.cancel()
+            self._observer.close()
+        if self._subscription is not None:
+            self._subscription.cancel()
+            self._subscription.close()
+
+
+async def run(
+    *,
+    robots: int = 3,
+    count: int = 6,
+    interval: float = 0.4,
+    sim: bool | None = None,
+    token: str | None = None,
+) -> dict[str, dict[str, tuple[float, float, float]]]:
+    """Drive ``robots`` robots for ``count`` ticks; return each robot's view of the fleet."""
+    resolved_sim = use_sim(sim)
+    rclpy = get_rclpy(resolved_sim)
+    database_id = str(uuid.uuid4())
+    token = token or offline_token()
+    rclpy.init()
+
+    members: list[FleetMember] = []
+    async with contextlib.AsyncExitStack() as stack:
+        for index in range(robots):
+            robot_id = f"robot-{index + 1}"
+            directory = stack.enter_context(tempfile.TemporaryDirectory(prefix=f"ditto-{robot_id}-"))
+            # Star topology: robot-1 is the hub; everyone else connects to it.
+            peer = await stack.enter_async_context(
+                open_peer(
+                    database_id=database_id,
+                    directory=directory,
+                    token=token,
+                    peer_port=_BASE_PORT + index,
+                    connect_ports=[] if index == 0 else [_BASE_PORT],
+                )
+            )
+            members.append(FleetMember(robot_id, peer, rclpy.create_node(robot_id), resolved_sim))
+
+        try:
+            for member in members:
+                await member.start()
+            for tick in range(count):
+                for index, member in enumerate(members):
+                    # Each robot follows its own little trajectory.
+                    member.publish_pose(x=tick * 0.1 + index, y=float(index), theta=tick * 0.2)
+                await asyncio.sleep(interval)
+                hub = members[0]
+                print(
+                    f"[fleet] tick {tick}: robot-1 sees "
+                    + ", ".join(f"{r}={xy[0]:.2f},{xy[1]:.2f}" for r, xy in sorted(hub.world.items())),
+                    flush=True,
+                )
+            # Drain until every robot sees the whole fleet (or we time out).
+            deadline = count * interval + 4.0
+            while deadline > 0 and not all(len(m.world) == robots for m in members):
+                await asyncio.sleep(0.05)
+                deadline -= 0.05
+            views = {m.robot_id: dict(m.world) for m in members}
+        finally:
+            for member in members:
+                await member.stop()
+            for member in members:
+                member._node.destroy_node()
+    rclpy.shutdown()
+    seen = min((len(v) for v in views.values()), default=0)
+    print(f"[fleet] every robot now shares one world model of {seen}/{robots} robots", flush=True)
+    return views

--- a/python-ros2/ditto_ros2/main.py
+++ b/python-ros2/ditto_ros2/main.py
@@ -1,0 +1,73 @@
+"""CLI for the Ditto ↔ ROS 2 quickstart demos.
+
+    ditto-ros2 talker-listener --sim
+    ditto-ros2 teleop --sim
+    ditto-ros2 fleet --sim --robots 4
+    ditto-ros2 all --sim
+
+Set an offline-only license token in ``DITTO_OFFLINE_TOKEN`` (a local ``.env``
+file is loaded automatically) so the peers activate; without it they run
+local-only. Drop ``--sim`` on a machine with ROS 2 installed to use real
+``rclpy`` and the standard message packages.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+from dotenv import load_dotenv
+
+from . import fleet, talker_listener, teleop
+
+_DEMOS = {
+    "talker-listener": "ROS 2 hello world across two graphs, joined by Ditto",
+    "teleop": "drive a robot from a separate control station over Ditto",
+    "fleet": "robots share a live world model through a Ditto collection",
+    "all": "run all three demos in sequence",
+}
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="ditto-ros2", description="Canonical ROS 2 examples bridged through Ditto."
+    )
+    subparsers = parser.add_subparsers(dest="demo", required=True)
+    for name, help_text in _DEMOS.items():
+        sub = subparsers.add_parser(name, help=help_text)
+        sub.add_argument(
+            "--sim", action="store_true", help="force the in-process rclpy shim (no ROS 2 needed)"
+        )
+        sub.add_argument("--count", type=int, default=6, help="messages/ticks to send")
+        sub.add_argument("--interval", type=float, default=0.4, help="seconds between messages")
+        if name in ("fleet", "all"):
+            sub.add_argument("--robots", type=int, default=3, help="number of robots (fleet demo)")
+    return parser
+
+
+async def _dispatch(args: argparse.Namespace) -> None:
+    sim = True if args.sim else None
+    robots = getattr(args, "robots", 3)
+    if args.demo in ("talker-listener", "all"):
+        print("== talker / listener ==", flush=True)
+        await talker_listener.run(count=args.count, interval=args.interval, sim=sim)
+    if args.demo in ("teleop", "all"):
+        print("== teleop ==", flush=True)
+        await teleop.run(count=args.count, interval=args.interval, sim=sim)
+    if args.demo in ("fleet", "all"):
+        print("== fleet ==", flush=True)
+        await fleet.run(robots=robots, count=args.count, interval=args.interval, sim=sim)
+
+
+def main(argv: list[str] | None = None) -> int:
+    load_dotenv()
+    args = _parser().parse_args(argv)
+    try:
+        asyncio.run(_dispatch(args))
+    except KeyboardInterrupt:
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python-ros2/ditto_ros2/messages.py
+++ b/python-ros2/ditto_ros2/messages.py
@@ -1,0 +1,85 @@
+"""Minimal message types mirroring the real ROS 2 messages the demos use.
+
+These mirror the field layout of ``std_msgs/msg/String``,
+``geometry_msgs/msg/Twist``, and ``geometry_msgs/msg/Pose`` so the demo code is
+identical whether it runs against the ``rclpy_shim`` (no ROS install) or a real
+ROS 2 stack. Each type provides plain-dict (de)serialization so messages
+round-trip cleanly through Ditto (CBOR).
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+@dataclass
+class Vector3:
+    """geometry_msgs/msg/Vector3 — an x/y/z triple."""
+
+    x: float = 0.0
+    y: float = 0.0
+    z: float = 0.0
+
+
+@dataclass
+class Twist:
+    """geometry_msgs/msg/Twist — linear + angular velocity."""
+
+    linear: Vector3 = field(default_factory=Vector3)
+    angular: Vector3 = field(default_factory=Vector3)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"linear": asdict(self.linear), "angular": asdict(self.angular)}
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> Twist:
+        linear = value.get("linear") or {}
+        angular = value.get("angular") or {}
+        return cls(
+            linear=Vector3(**{k: float(v) for k, v in linear.items() if k in ("x", "y", "z")}),
+            angular=Vector3(**{k: float(v) for k, v in angular.items() if k in ("x", "y", "z")}),
+        )
+
+
+@dataclass
+class String:
+    """std_msgs/msg/String."""
+
+    data: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"data": self.data}
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> String:
+        return cls(data=str(value.get("data", "")))
+
+
+@dataclass
+class Pose:
+    """A pose on the plane: position ``(x, y)`` and heading ``theta`` (radians).
+
+    A deliberately small stand-in for ``geometry_msgs/msg/Pose`` so the fleet
+    demo stays readable; the real message nests position/orientation the same
+    way and round-trips through the same ``to_dict``/``from_dict`` contract.
+    """
+
+    x: float = 0.0
+    y: float = 0.0
+    theta: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"x": self.x, "y": self.y, "theta": self.theta}
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> Pose:
+        return cls(
+            x=float(value.get("x", 0.0)),
+            y=float(value.get("y", 0.0)),
+            theta=float(value.get("theta", 0.0)),
+        )
+
+
+# Registry so a route/demo can name its message type as a string (as ROS does).
+MESSAGE_TYPES: dict[str, type] = {"Twist": Twist, "String": String, "Pose": Pose}

--- a/python-ros2/ditto_ros2/peers.py
+++ b/python-ros2/ditto_ros2/peers.py
@@ -1,0 +1,68 @@
+"""Helpers for opening offline Ditto peers wired into a loopback mesh.
+
+The demos run several peers in one process and connect them over loopback TCP so
+they genuinely sync peer-to-peer (no cloud, no broker) — the same code path a
+real multi-robot deployment uses over Wi-Fi/LAN/BLE.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from collections.abc import AsyncIterator, Iterable
+
+from ditto import Ditto, DittoConfig, DittoConfigConnect, DittoTransportConfig
+
+LICENSE_ENV = "DITTO_OFFLINE_TOKEN"
+
+
+def offline_token() -> str | None:
+    """The offline-only license token from the environment, if set."""
+
+    token = os.environ.get(LICENSE_ENV, "").strip()
+    return token or None
+
+
+def _loopback_transport(peer_port: int, connect_ports: Iterable[int]) -> DittoTransportConfig | None:
+    if not peer_port:
+        return None
+    transport = DittoTransportConfig()
+    transport.listen.tcp.enabled = True
+    transport.listen.tcp.interface_ip = "127.0.0.1"
+    transport.listen.tcp.port = peer_port
+    for connect_port in connect_ports:
+        transport.connect.tcp_servers.add(f"127.0.0.1:{connect_port}")
+    return transport
+
+
+@contextlib.asynccontextmanager
+async def open_peer(
+    *,
+    database_id: str,
+    directory: str,
+    token: str | None = None,
+    peer_port: int = 0,
+    connect_ports: Iterable[int] = (),
+) -> AsyncIterator[Ditto]:
+    """Open an offline peer (optionally on a loopback TCP mesh) and close it on exit.
+
+    Peers that share ``database_id`` and are linked by matching listen/connect
+    ports sync with each other. ``token`` is the offline-only license; without
+    it the peer runs local-only (fine for a single-process demo).
+    """
+    peer = await Ditto.open(
+        DittoConfig(
+            database_id=database_id,
+            connect=DittoConfigConnect.small_peers_only(),
+            persistence_directory=directory,
+        )
+    )
+    try:
+        if token:
+            peer.set_offline_only_license_token(token)
+        transport = _loopback_transport(peer_port, connect_ports)
+        if transport is not None:
+            peer.transport_config = transport
+        yield peer
+    finally:
+        await peer.close()

--- a/python-ros2/ditto_ros2/rclpy_shim.py
+++ b/python-ros2/ditto_ros2/rclpy_shim.py
@@ -1,0 +1,139 @@
+"""A tiny in-process stand-in for ``rclpy`` so the demos run and are tested
+without a ROS 2 installation.
+
+It implements just the surface the demos use -- ``init`` / ``shutdown`` / ``ok``
+/ ``create_node`` / ``spin_once`` and a ``Node`` with ``create_publisher`` /
+``create_subscription`` -- with faithful names and signatures.
+
+Two design choices make the demos meaningful:
+
+* **Delivery happens on spin, not on publish.** ``publish()`` only enqueues;
+  ``spin_once(node)`` dispatches that node's queued messages to its callbacks,
+  exactly as a real node must be spun to receive.
+* **Delivery is per node.** A publisher reaches only its own node's
+  subscribers, the way two robots on separate DDS domains stay isolated until
+  something bridges them. Here that bridge is Ditto -- so the only path from one
+  robot's topic to another robot's subscriber is through Ditto sync, which is
+  the whole point of these demos.
+
+This is a test/dev double, not a ROS 2 implementation: no networking, no real
+executor, no DDS QoS matching.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import deque
+from collections.abc import Callable
+from typing import Any
+
+_log = logging.getLogger("ditto_ros2.rclpy_shim")
+
+_initialized = False
+
+
+def init(args: list[str] | None = None, *, context: Any = None) -> None:
+    global _initialized
+    _initialized = True
+
+
+def shutdown(*, context: Any = None) -> None:
+    global _initialized
+    _initialized = False
+
+
+def ok(context: Any = None) -> bool:
+    return _initialized
+
+
+class Publisher:
+    def __init__(self, node: Node, msg_type: type[Any], topic: str, qos: Any) -> None:
+        self._node = node
+        self.msg_type = msg_type
+        self.topic = topic
+        self.qos = qos
+
+    def publish(self, message: Any) -> None:
+        if not isinstance(message, self.msg_type):
+            raise TypeError(
+                f"Publisher on {self.topic!r} expected {self.msg_type.__name__}, "
+                f"got {type(message).__name__}"
+            )
+        # Enqueue for delivery on the next spin_once of this node. Only this
+        # node's own subscribers see it (per-node isolation, see module docstring).
+        for subscription in list(self._node._subscriptions.get(self.topic, ())):
+            self._node._inbox.append((subscription.callback, message))
+
+
+class Subscription:
+    def __init__(self, topic: str, callback: Callable[[Any], None]) -> None:
+        self.topic = topic
+        self.callback = callback
+
+
+class Node:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._subscriptions: dict[str, list[Subscription]] = {}
+        self._publishers: list[Publisher] = []
+        self._inbox: deque[tuple[Callable[[Any], None], Any]] = deque()
+
+    def get_name(self) -> str:
+        return self.name
+
+    def create_publisher(self, msg_type: type[Any], topic: str, qos: Any = 10) -> Publisher:
+        publisher = Publisher(self, msg_type, topic, qos)
+        self._publishers.append(publisher)
+        return publisher
+
+    def create_subscription(
+        self,
+        msg_type: type[Any],
+        topic: str,
+        callback: Callable[[Any], None],
+        qos: Any = 10,
+    ) -> Subscription:
+        subscription = Subscription(topic, callback)
+        self._subscriptions.setdefault(topic, []).append(subscription)
+        return subscription
+
+    def destroy_subscription(self, subscription: Subscription) -> None:
+        peers = self._subscriptions.get(subscription.topic)
+        if peers:
+            self._subscriptions[subscription.topic] = [s for s in peers if s is not subscription]
+
+    def destroy_node(self) -> None:
+        self._subscriptions.clear()
+        self._publishers.clear()
+        self._inbox.clear()
+
+
+def create_node(name: str) -> Node:
+    return Node(name)
+
+
+def spin_once(node: Node, *, executor: Any = None, timeout_sec: float | None = None) -> None:
+    """Dispatch the messages queued for ``node`` at entry to their callbacks.
+
+    Only the batch present when the call begins is delivered, so a callback that
+    publishes back to its own node cannot spin forever within a single call.
+    """
+
+    for _ in range(len(node._inbox)):
+        callback, message = node._inbox.popleft()
+        try:
+            callback(message)
+        except Exception:
+            _log.exception("Unhandled exception in a ROS subscription callback")
+
+
+__all__ = [
+    "Node",
+    "Publisher",
+    "Subscription",
+    "create_node",
+    "init",
+    "ok",
+    "shutdown",
+    "spin_once",
+]

--- a/python-ros2/ditto_ros2/ros_compat.py
+++ b/python-ros2/ditto_ros2/ros_compat.py
@@ -1,0 +1,51 @@
+"""The one place that chooses between real ROS 2 (``rclpy``) and the shim.
+
+Everything else imports ``rclpy`` and message types from here, so the demos are
+identical in simulation and on a robot. Use ``--sim`` (or set ``DITTO_ROS_SIM=1``)
+to force the shim even when a real ROS 2 is importable.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, cast
+
+from . import messages as sim_messages
+
+
+def use_sim(explicit: bool | None = None) -> bool:
+    if explicit is not None:
+        return explicit
+    if os.environ.get("DITTO_ROS_SIM", "").strip() in ("1", "true", "yes", "on"):
+        return True
+    try:
+        import rclpy  # noqa: F401
+    except ImportError:
+        return True
+    return False
+
+
+def get_rclpy(sim: bool | None = None) -> Any:
+    if use_sim(sim):
+        from . import rclpy_shim
+
+        return rclpy_shim
+    import rclpy
+
+    return rclpy
+
+
+def get_message_type(name: str, sim: bool | None = None) -> type:
+    """Resolve a message type by short name (``"String"``, ``"Twist"``, ``"Pose"``)."""
+
+    if use_sim(sim):
+        return sim_messages.MESSAGE_TYPES[name]
+    # Real ROS 2: map short names to their standard packages. "Pose" maps to
+    # geometry_msgs/Pose2D, whose (x, y, theta) fields match our simplified Pose.
+    if name == "String":
+        import std_msgs.msg as std
+
+        return cast(type, std.String)
+    import geometry_msgs.msg as geometry
+
+    return cast(type, getattr(geometry, "Pose2D" if name == "Pose" else name))

--- a/python-ros2/ditto_ros2/talker_listener.py
+++ b/python-ros2/ditto_ros2/talker_listener.py
@@ -1,0 +1,98 @@
+"""Demo 1 — talker / listener, the ROS 2 "hello world", across two graphs.
+
+A talker publishes ``std_msgs/String`` on ``/chatter``. A listener subscribes to
+``/chatter`` — but it runs in a *separate* ROS graph (a second peer), so DDS
+pub/sub alone would never connect them. The only link is Ditto: the talker's
+node bridges ``/chatter`` into a Ditto collection, Ditto syncs it to the second
+peer, and that peer republishes it onto its own ``/chatter`` for the listener.
+
+Takeaway: Ditto carries ROS 2 pub/sub across graphs and networks a single DDS
+domain can't span — offline and broker-free.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import tempfile
+import uuid
+
+from .bridge import DittoRos2Bridge, Route
+from .peers import offline_token, open_peer
+from .ros_compat import get_message_type, get_rclpy, use_sim
+
+
+async def run(
+    *, count: int = 6, interval: float = 0.4, sim: bool | None = None, token: str | None = None
+) -> list[str]:
+    """Publish ``count`` messages on the talker; return what the listener heard."""
+    resolved_sim = use_sim(sim)
+    rclpy = get_rclpy(resolved_sim)
+    string_type = get_message_type("String", resolved_sim)
+    database_id = str(uuid.uuid4())
+    token = token or offline_token()
+    heard: list[str] = []
+
+    rclpy.init()
+    async with contextlib.AsyncExitStack() as stack:
+        with tempfile.TemporaryDirectory(prefix="ditto-ros2-talker-") as dir_a, tempfile.TemporaryDirectory(
+            prefix="ditto-ros2-listener-"
+        ) as dir_b:
+            talker_peer = await stack.enter_async_context(
+                open_peer(database_id=database_id, directory=dir_a, token=token, peer_port=4101)
+            )
+            listener_peer = await stack.enter_async_context(
+                open_peer(
+                    database_id=database_id,
+                    directory=dir_b,
+                    token=token,
+                    peer_port=4102,
+                    connect_ports=[4101],
+                )
+            )
+
+            talker_node = rclpy.create_node("talker")
+            listener_node = rclpy.create_node("listener")
+
+            def on_chatter(message: object) -> None:
+                text = getattr(message, "data", "")
+                heard.append(text)
+                print(f"[listener] heard: {text!r}", flush=True)
+
+            listener_node.create_subscription(string_type, "/chatter", on_chatter, 10)
+            chatter = talker_node.create_publisher(string_type, "/chatter", 10)
+
+            talker_bridge = DittoRos2Bridge(
+                talker_peer,
+                talker_node,
+                [Route("chatter", "/chatter", "String", "ros_to_ditto")],
+                robot_id="talker",
+                sim=resolved_sim,
+            )
+            listener_bridge = DittoRos2Bridge(
+                listener_peer,
+                listener_node,
+                [Route("chatter", "/chatter", "String", "ditto_to_ros")],
+                robot_id="listener",
+                sim=resolved_sim,
+            )
+            try:
+                await talker_bridge.start()
+                await listener_bridge.start()
+                for index in range(count):
+                    chatter.publish(string_type(data=f"hello world {index}"))
+                    print(f"[talker] said: 'hello world {index}'", flush=True)
+                    await asyncio.sleep(interval)
+                # Drain: give the last messages time to sync + republish.
+                deadline = count * interval + 3.0
+                while len(heard) < count and deadline > 0:
+                    await asyncio.sleep(0.05)
+                    deadline -= 0.05
+            finally:
+                await talker_bridge.stop()
+                await listener_bridge.stop()
+                talker_node.destroy_node()
+                listener_node.destroy_node()
+    rclpy.shutdown()
+    print(f"[talker/listener] delivered {len(heard)}/{count} messages via Ditto", flush=True)
+    return heard

--- a/python-ros2/ditto_ros2/teleop.py
+++ b/python-ros2/ditto_ros2/teleop.py
@@ -1,0 +1,107 @@
+"""Demo 2 — teleop: drive a robot from a separate control station over Ditto.
+
+A control station publishes ``geometry_msgs/Twist`` velocity commands on
+``/cmd_vel``. The robot subscribes to ``/cmd_vel`` — but it's a separate peer on
+the mesh, so the commands reach it only through Ditto. Bridge the control
+station's ``/cmd_vel`` into Ditto, sync, and republish onto the robot's
+``/cmd_vel``; the robot acts on each command as it arrives.
+
+Takeaway: command-and-control survives an intermittent link — commands queue in
+Ditto and converge when the robot reconnects, with no central broker.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import math
+import tempfile
+import uuid
+
+from .bridge import DittoRos2Bridge, Route
+from .peers import offline_token, open_peer
+from .ros_compat import get_message_type, get_rclpy, use_sim
+
+
+async def run(
+    *, count: int = 6, interval: float = 0.4, sim: bool | None = None, token: str | None = None
+) -> list[tuple[float, float]]:
+    """Send ``count`` velocity commands; return the (linear.x, angular.z) the robot acted on."""
+    resolved_sim = use_sim(sim)
+    rclpy = get_rclpy(resolved_sim)
+    twist_type = get_message_type("Twist", resolved_sim)
+    database_id = str(uuid.uuid4())
+    token = token or offline_token()
+    driven: list[tuple[float, float]] = []
+
+    rclpy.init()
+    async with contextlib.AsyncExitStack() as stack:
+        with tempfile.TemporaryDirectory(prefix="ditto-ros2-control-") as dir_c, tempfile.TemporaryDirectory(
+            prefix="ditto-ros2-robot-"
+        ) as dir_r:
+            control_peer = await stack.enter_async_context(
+                open_peer(database_id=database_id, directory=dir_c, token=token, peer_port=4111)
+            )
+            robot_peer = await stack.enter_async_context(
+                open_peer(
+                    database_id=database_id,
+                    directory=dir_r,
+                    token=token,
+                    peer_port=4112,
+                    connect_ports=[4111],
+                )
+            )
+
+            control_node = rclpy.create_node("control_station")
+            robot_node = rclpy.create_node("robot")
+
+            def on_cmd_vel(message: object) -> None:
+                linear = getattr(message, "linear", None)
+                angular = getattr(message, "angular", None)
+                lx = round(float(getattr(linear, "x", 0.0)), 3)
+                az = round(float(getattr(angular, "z", 0.0)), 3)
+                driven.append((lx, az))
+                print(f"[robot] driving: linear.x={lx} angular.z={az}", flush=True)
+
+            robot_node.create_subscription(twist_type, "/cmd_vel", on_cmd_vel, 10)
+            cmd_vel = control_node.create_publisher(twist_type, "/cmd_vel", 10)
+
+            control_bridge = DittoRos2Bridge(
+                control_peer,
+                control_node,
+                [Route("cmd_vel", "/cmd_vel", "Twist", "ros_to_ditto")],
+                robot_id="control",
+                sim=resolved_sim,
+            )
+            robot_bridge = DittoRos2Bridge(
+                robot_peer,
+                robot_node,
+                [Route("cmd_vel", "/cmd_vel", "Twist", "ditto_to_ros")],
+                robot_id="robot",
+                sim=resolved_sim,
+            )
+            try:
+                await control_bridge.start()
+                await robot_bridge.start()
+                for index in range(count):
+                    twist = twist_type()
+                    twist.linear.x = round(0.5 + 0.5 * math.sin(index * interval), 3)
+                    twist.angular.z = round(0.3 * math.cos(index * interval), 3)
+                    cmd_vel.publish(twist)
+                    print(
+                        f"[control] send: linear.x={twist.linear.x} angular.z={twist.angular.z}",
+                        flush=True,
+                    )
+                    await asyncio.sleep(interval)
+                deadline = count * interval + 3.0
+                while len(driven) < count and deadline > 0:
+                    await asyncio.sleep(0.05)
+                    deadline -= 0.05
+            finally:
+                await control_bridge.stop()
+                await robot_bridge.stop()
+                control_node.destroy_node()
+                robot_node.destroy_node()
+    rclpy.shutdown()
+    print(f"[teleop] robot acted on {len(driven)}/{count} commands via Ditto", flush=True)
+    return driven

--- a/python-ros2/docker/Dockerfile
+++ b/python-ros2/docker/Dockerfile
@@ -1,0 +1,17 @@
+# Real ROS 2 (Humble) image with the Ditto Python SDK + this quickstart
+# installed, running a demo against genuine rclpy + geometry_msgs/std_msgs.
+FROM ros:humble-ros-base
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/ditto-ros2
+# Build context is the python-ros2 quickstart directory (see docker-compose.yml).
+# The SDK bundles libdittoffi for the image's platform (amd64 or arm64 wheel).
+COPY . /opt/ditto-ros2/
+RUN pip3 install --no-cache-dir .
+
+# `--sim` is intentionally omitted: with ROS 2 present, ros_compat uses real rclpy.
+# Set DITTO_OFFLINE_TOKEN in the environment (see docker-compose.yml) to activate.
+CMD ["bash", "-lc", "source /opt/ros/humble/setup.bash && ditto-ros2 fleet --robots 3"]

--- a/python-ros2/docker/docker-compose.yml
+++ b/python-ros2/docker/docker-compose.yml
@@ -1,0 +1,15 @@
+# Run a demo against real ROS 2:
+#   DITTO_OFFLINE_TOKEN=<token> docker compose -f docker/docker-compose.yml up --build
+#
+# Override the demo with:  command: ["bash","-lc","source /opt/ros/humble/setup.bash && ditto-ros2 talker-listener"]
+services:
+  ditto-ros2:
+    build:
+      # Context is the quickstart dir (one level up) so the package + pyproject
+      # are copied into the image.
+      context: ..
+      dockerfile: docker/Dockerfile
+    environment:
+      DITTO_OFFLINE_TOKEN: ${DITTO_OFFLINE_TOKEN:-}
+    # ROS 2 defaults to multicast DDS discovery; keep it self-contained.
+    network_mode: bridge

--- a/python-ros2/pyproject.toml
+++ b/python-ros2/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "ditto-quickstart-python-ros2"
+version = "0.1.0"
+description = "Ditto Python SDK quickstart — canonical ROS 2 examples bridged through Ditto."
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "dittolive-ditto>=5.1.0.dev0",
+    "python-dotenv>=1.0.0",
+]
+
+# Real ROS 2 (`rclpy`, `std_msgs`, `geometry_msgs`) is provided by a ROS 2
+# installation, not pip. Without it, the demos fall back to the bundled rclpy
+# shim (or force it with --sim).
+
+[project.scripts]
+ditto-ros2 = "ditto_ros2.main:main"
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["ditto_ros2"]

--- a/python-ros2/tests/test_demos.py
+++ b/python-ros2/tests/test_demos.py
@@ -1,0 +1,38 @@
+"""Smoke tests: each demo runs in --sim and proves data crossed via Ditto.
+
+Requires an offline-only license token in ``DITTO_OFFLINE_TOKEN`` (the peers
+must activate to sync); the tests skip without it so the suite stays portable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+from ditto_ros2 import fleet, talker_listener, teleop
+
+_TOKEN = os.environ.get("DITTO_OFFLINE_TOKEN", "").strip()
+requires_token = pytest.mark.skipif(not _TOKEN, reason="set DITTO_OFFLINE_TOKEN to run the demos")
+
+
+@requires_token
+def test_talker_listener_crosses_graphs() -> None:
+    heard = asyncio.run(talker_listener.run(count=4, interval=0.2, sim=True, token=_TOKEN))
+    assert heard == [f"hello world {i}" for i in range(4)]
+
+
+@requires_token
+def test_teleop_commands_reach_the_robot() -> None:
+    driven = asyncio.run(teleop.run(count=4, interval=0.2, sim=True, token=_TOKEN))
+    assert len(driven) == 4
+
+
+@requires_token
+def test_fleet_shares_one_world_model() -> None:
+    views = asyncio.run(fleet.run(robots=3, count=4, interval=0.2, sim=True, token=_TOKEN))
+    # Every robot sees every robot's latest pose.
+    assert set(views) == {"robot-1", "robot-2", "robot-3"}
+    for view in views.values():
+        assert set(view) == {"robot-1", "robot-2", "robot-3"}

--- a/python-tui/.gitignore
+++ b/python-tui/.gitignore
@@ -1,0 +1,6 @@
+.venv/
+__pycache__/
+*.pyc
+.env
+ditto-python-tui-*/
+*.egg-info/

--- a/python-tui/README.md
+++ b/python-tui/README.md
@@ -1,0 +1,135 @@
+# Ditto Python Quickstart App 🚀
+
+This directory contains Ditto's quickstart app for the Python SDK
+(`dittolive-ditto`). It is a console app that manages a todo list which syncs
+between multiple peers, sharing the same `tasks` collection as every other
+quickstart app in this repo.
+
+It runs on **Linux (including Raspberry Pi / aarch64), macOS, and Windows**.
+
+## Prerequisites
+
+- **Python 3.10 or newer**
+- [`uv`](https://docs.astral.sh/uv/) or `pip` for managing a virtual environment
+
+## Getting Started
+
+To get started, you'll first need to create an app in the [Ditto Portal][0]
+with the "Online Playground" authentication type. You'll need your AppID,
+Online Playground Token, Auth URL, and Websocket URL to use this quickstart.
+
+[0]: https://portal.ditto.live
+
+From the repo root, copy `.env.sample` to `.env` and fill in your credentials:
+
+```bash
+cp .env.sample .env
+```
+
+```bash
+DITTO_APP_ID=""
+DITTO_PLAYGROUND_TOKEN=""
+DITTO_AUTH_URL=""
+DITTO_WEBSOCKET_URL=""
+```
+
+Alternatively, export them as environment variables.
+
+## Install
+
+`dittolive-ditto` is **not yet published to PyPI**, so install the SDK editable
+from your Ditto monorepo checkout **first**, then this app. From this directory
+(`python-tui`):
+
+```bash
+# Using pip (python -m venv includes pip):
+python3 -m venv .venv
+.venv/bin/pip install -e /path/to/ditto/sdks/python   # the SDK (not on PyPI yet)
+.venv/bin/pip install -e .                             # this app (+ python-dotenv)
+```
+
+```bash
+# Using uv (note: `uv venv` does NOT include pip — use `uv pip`, not `python -m pip`):
+uv venv --python 3.12 .venv
+uv pip install -e /path/to/ditto/sdks/python
+uv pip install -e .
+```
+
+The editable SDK install lets the loader auto-discover a locally built
+`libdittoffi` (build it with `make build-mac` / `make build-linux` from the
+monorepo; the loader also honors `DITTOFFI_LIB_PATH`). Once `dittolive-ditto`
+is published, `pip install -e .` alone will pull the SDK from PyPI.
+
+## Running
+
+```bash
+.venv/bin/python main.py
+```
+
+The app reads its configuration from the environment:
+
+- **Cloud (Big Peer) mode** — used automatically when `DITTO_APP_ID` is set.
+  Requires `DITTO_APP_ID`, `DITTO_PLAYGROUND_TOKEN`, and `DITTO_AUTH_URL`.
+  Peers sync through your Big Peer.
+- **Offline (peer-to-peer) mode** — used when `DITTO_APP_ID` is unset and
+  `DITTO_OFFLINE_TOKEN` (an offline license token) is set. No cloud is
+  required; peers on the same network discover and sync over LAN/mDNS and the
+  other peer-to-peer transports.
+
+```bash
+# Offline P2P, no cloud account needed
+DITTO_OFFLINE_TOKEN="your-offline-license" .venv/bin/python main.py
+```
+
+Unlike the full-screen TUI quickstarts, this is a line-oriented console app, so
+there is no need to redirect stderr. Ditto's log level is set to `ERROR` to keep
+the output clean.
+
+## Controls
+
+At the `>` prompt:
+
+- `add <title>` — create a task
+- `done <n>` — toggle task number `n` complete/incomplete
+- `edit <n> <title>` — rename task number `n`
+- `del <n>` — delete task number `n`
+- `list` (or press Enter) — refresh the list (shows changes synced from peers)
+- `help` — show commands
+- `quit` — exit
+
+## Data Model
+
+All quickstart apps share the same `tasks` collection so they interoperate:
+
+```json
+{
+  "_id": "unique-id",
+  "title": "Task description",
+  "done": false,
+  "deleted": false
+}
+```
+
+## Smoke test
+
+A non-interactive check opens Ditto offline, inserts a task, observes it, and
+exits. It reads the offline license from `DITTO_OFFLINE_TOKEN`:
+
+```bash
+DITTO_OFFLINE_TOKEN="your-offline-license" .venv/bin/python main.py --smoke
+```
+
+## Troubleshooting
+
+### libdittoffi library not found
+
+The Python SDK loads `libdittoffi` at first use. If you see a loader error, set
+`DITTOFFI_LIB_PATH` to the built library (or its directory), or ensure it is on
+the system library path. See the [Python SDK install guide][1].
+
+[1]: https://docs.ditto.live/sdk/latest/install-guides/python
+
+### Environment variables not found
+
+The app loads a `.env` file from the current directory or a parent directory.
+Ensure it exists with the required variables, or export them directly.

--- a/python-tui/main.py
+++ b/python-tui/main.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Ditto Python quickstart — a Tasks console app that syncs peer-to-peer.
+
+This mirrors the other quickstart apps (rust-tui, go-tui, javascript-tui): it
+manages a shared "tasks" collection with the canonical cross-SDK schema so it
+interoperates with every other quickstart app.
+
+    { "_id": str, "title": str, "done": bool, "deleted": bool }
+
+Two modes are selected by environment (see the README):
+
+  * cloud   — Big Peer sync via an Online Playground identity
+              (DITTO_APP_ID, DITTO_PLAYGROUND_TOKEN, DITTO_AUTH_URL)
+  * offline — small-peers-only P2P using an offline license token
+              (DITTO_OFFLINE_TOKEN), no cloud required
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import shutil
+import sys
+import tempfile
+import uuid
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any
+
+from dotenv import load_dotenv
+
+from ditto import (
+    AuthenticationProvider,
+    Ditto,
+    DittoConfig,
+    DittoConfigConnect,
+    DittoLogger,
+    DittoTransportConfig,
+    LogLevel,
+    QueryResult,
+)
+
+# The observer view hides soft-deleted tasks; the subscription syncs everything
+# so tombstones propagate to other peers.
+TASKS_QUERY = "SELECT * FROM tasks WHERE deleted = false ORDER BY title"
+SUBSCRIPTION_QUERY = "SELECT * FROM tasks"
+
+
+@dataclass
+class Task:
+    id: str
+    title: str
+    done: bool
+
+    @classmethod
+    def from_value(cls, value: dict[str, Any]) -> "Task":
+        return cls(
+            id=str(value["_id"]),
+            title=str(value.get("title", "")),
+            done=bool(value.get("done", False)),
+        )
+
+
+@dataclass
+class Settings:
+    mode: str  # "cloud" or "offline"
+    database_id: str
+    persistence_directory: str
+    auth_url: str | None = None
+    playground_token: str | None = None
+    offline_token: str | None = None
+
+
+def load_settings(*, force_offline: bool = False) -> Settings:
+    """Read configuration from the environment (and a nearest .env file).
+
+    Cloud mode is chosen when DITTO_APP_ID is set; otherwise the app runs
+    offline with DITTO_OFFLINE_TOKEN. ``force_offline`` is used by --smoke.
+    """
+
+    load_dotenv()  # walks up from the current directory to find a .env
+
+    app_id = os.environ.get("DITTO_APP_ID", "").strip()
+    offline_token = os.environ.get("DITTO_OFFLINE_TOKEN", "").strip()
+    persistence_directory = tempfile.mkdtemp(prefix="ditto-python-tui-")
+
+    use_cloud = bool(app_id) and not force_offline
+    if use_cloud:
+        token = os.environ.get("DITTO_PLAYGROUND_TOKEN", "").strip()
+        auth_url = os.environ.get("DITTO_AUTH_URL", "").strip()
+        if not token or not auth_url:
+            raise SystemExit(
+                "Cloud mode needs DITTO_PLAYGROUND_TOKEN and DITTO_AUTH_URL "
+                "(set DITTO_OFFLINE_TOKEN instead to run offline)."
+            )
+        return Settings(
+            mode="cloud",
+            database_id=app_id,
+            persistence_directory=persistence_directory,
+            auth_url=auth_url,
+            playground_token=token,
+        )
+
+    if not offline_token:
+        raise SystemExit(
+            "No credentials found. Set DITTO_APP_ID + DITTO_PLAYGROUND_TOKEN + "
+            "DITTO_AUTH_URL for cloud sync, or DITTO_OFFLINE_TOKEN for offline "
+            "peer-to-peer. See the README."
+        )
+    return Settings(
+        mode="offline",
+        # An explicit APP_ID lets offline peers share a database; otherwise fall
+        # back to the SDK default so two local peers still mesh.
+        database_id=app_id or DittoConfig.DEFAULT_DATABASE_ID,
+        persistence_directory=persistence_directory,
+        offline_token=offline_token,
+    )
+
+
+def build_config(settings: Settings) -> DittoConfig:
+    connect = (
+        DittoConfigConnect.server(settings.auth_url or "")
+        if settings.mode == "cloud"
+        else DittoConfigConnect.small_peers_only()
+    )
+    return DittoConfig(
+        database_id=settings.database_id,
+        connect=connect,
+        persistence_directory=settings.persistence_directory,
+    )
+
+
+async def activate(peer: Ditto, settings: Settings) -> None:
+    """Authenticate (cloud) or install the offline license before syncing."""
+
+    if settings.mode == "offline":
+        peer.set_offline_only_license_token(settings.offline_token or "")
+        # Enable local peer-to-peer transports so peers on the same network mesh.
+        peer.transport_config = DittoTransportConfig().enable_all_peer_to_peer()
+        return
+
+    authenticator = peer.auth
+    if authenticator is None:
+        raise SystemExit("Cloud configuration did not create an authenticator.")
+
+    async def refresh(_peer: Ditto, _remaining: timedelta) -> None:
+        await authenticator.login(
+            settings.playground_token or "", AuthenticationProvider.DEVELOPMENT
+        )
+
+    authenticator.expiration_handler = refresh
+    await authenticator.login(
+        settings.playground_token or "", AuthenticationProvider.DEVELOPMENT
+    )
+
+
+class TasksApp:
+    """Owns the Ditto subscription/observer and the tasks CRUD operations."""
+
+    def __init__(self, peer: Ditto, settings: Settings) -> None:
+        self.peer = peer
+        self.settings = settings
+        self.tasks: list[Task] = []
+        self._subscription: Any | None = None
+        self._observer: Any | None = None
+        # The observer callback is delivered on this loop, so a plain Event is
+        # enough to notice the first snapshot.
+        self._updated = asyncio.Event()
+
+    async def start(self) -> None:
+        self._subscription = self.peer.sync.register_subscription(SUBSCRIPTION_QUERY)
+        self._observer = self.peer.store.register_observer(TASKS_QUERY, self._on_change)
+        self.peer.sync.start()
+
+    def _on_change(self, result: QueryResult) -> None:
+        try:
+            self.tasks = [Task.from_value(item.value) for item in result]
+        finally:
+            result.close()
+        self._updated.set()
+
+    async def _mutate(self, coro: Any) -> None:
+        """Run a write, then wait for the observer to reflect it.
+
+        The observer callback lands on this event loop slightly after the
+        write commits, so waiting keeps the next render in sync with the store.
+        """
+
+        self._updated.clear()
+        await coro
+        try:
+            await asyncio.wait_for(self._updated.wait(), timeout=2.0)
+        except asyncio.TimeoutError:
+            pass
+
+    async def add(self, title: str) -> None:
+        task = {"_id": str(uuid.uuid4()), "title": title, "done": False, "deleted": False}
+        with await self.peer.store.execute(
+            "INSERT INTO tasks DOCUMENTS (:task)", {"task": task}
+        ):
+            pass
+
+    async def toggle(self, task: Task) -> None:
+        with await self.peer.store.execute(
+            "UPDATE tasks SET done = :done WHERE _id = :id",
+            {"done": not task.done, "id": task.id},
+        ):
+            pass
+
+    async def edit(self, task: Task, title: str) -> None:
+        with await self.peer.store.execute(
+            "UPDATE tasks SET title = :title WHERE _id = :id",
+            {"title": title, "id": task.id},
+        ):
+            pass
+
+    async def delete(self, task: Task) -> None:
+        with await self.peer.store.execute(
+            "UPDATE tasks SET deleted = true WHERE _id = :id", {"id": task.id}
+        ):
+            pass
+
+    async def stop(self) -> None:
+        if self._observer is not None:
+            self._observer.cancel()
+            self._observer.close()
+        if self._subscription is not None:
+            self._subscription.cancel()
+            self._subscription.close()
+
+    # --- Console UI -------------------------------------------------------
+
+    def render(self) -> None:
+        print("\n" + "=" * 52)
+        print(f"  Ditto Tasks  ({self.settings.mode} mode)")
+        print("=" * 52)
+        if not self.tasks:
+            print("  (no tasks yet — try 'add Buy milk')")
+        else:
+            for index, task in enumerate(self.tasks, start=1):
+                box = "[x]" if task.done else "[ ]"
+                print(f"  {index:>2}. {box} {task.title}")
+        print("-" * 52)
+        print("  add <title>   done <n>   edit <n> <title>   del <n>")
+        print("  list          help       quit")
+
+    def _resolve(self, token: str) -> Task | None:
+        try:
+            index = int(token)
+        except ValueError:
+            print(f"  '{token}' is not a task number.")
+            return None
+        if 1 <= index <= len(self.tasks):
+            return self.tasks[index - 1]
+        print(f"  No task #{index}.")
+        return None
+
+    async def _read(self, prompt: str) -> str:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, lambda: input(prompt))
+
+    async def repl(self) -> None:
+        print(
+            "\nConnected. Changes from other peers appear when you refresh "
+            "(press Enter or type 'list')."
+        )
+        while True:
+            self.render()
+            try:
+                line = (await self._read("\n> ")).strip()
+            except (EOFError, KeyboardInterrupt):
+                print()
+                return
+
+            if not line:
+                continue
+
+            parts = line.split(maxsplit=1)
+            command = parts[0].lower()
+            rest = parts[1].strip() if len(parts) > 1 else ""
+
+            if command in ("quit", "q", "exit"):
+                return
+            elif command in ("list", "l"):
+                continue
+            elif command in ("help", "h", "?"):
+                self._print_help()
+            elif command in ("add", "a"):
+                if rest:
+                    await self._mutate(self.add(rest))
+                else:
+                    print("  Usage: add <title>")
+            elif command in ("done", "toggle", "t"):
+                task = self._resolve(rest)
+                if task is not None:
+                    await self._mutate(self.toggle(task))
+            elif command in ("edit", "e"):
+                edit_parts = rest.split(maxsplit=1)
+                if len(edit_parts) == 2:
+                    task = self._resolve(edit_parts[0])
+                    if task is not None:
+                        await self._mutate(self.edit(task, edit_parts[1].strip()))
+                else:
+                    print("  Usage: edit <n> <new title>")
+            elif command in ("del", "delete", "d"):
+                task = self._resolve(rest)
+                if task is not None:
+                    await self._mutate(self.delete(task))
+            else:
+                print(f"  Unknown command: {command} (try 'help')")
+
+    @staticmethod
+    def _print_help() -> None:
+        print(
+            "\n  Commands:\n"
+            "    add <title>         create a task\n"
+            "    done <n>            toggle task #n complete/incomplete\n"
+            "    edit <n> <title>    rename task #n\n"
+            "    del <n>             delete task #n\n"
+            "    list                refresh the list (also: press Enter)\n"
+            "    quit                exit"
+        )
+
+
+async def run_tui(settings: Settings) -> int:
+    DittoLogger.minimum_log_level = LogLevel.ERROR
+    config = build_config(settings)
+    async with Ditto.open(config) as peer:
+        await activate(peer, settings)
+        app = TasksApp(peer, settings)
+        await app.start()
+        try:
+            # Give the first local snapshot a moment to arrive before drawing.
+            await asyncio.wait_for(app._updated.wait(), timeout=5)
+        except asyncio.TimeoutError:
+            pass
+        try:
+            await app.repl()
+        finally:
+            await app.stop()
+    return 0
+
+
+async def run_smoke(settings: Settings) -> int:
+    """Non-interactive check: open offline, insert, observe, print, exit 0."""
+
+    DittoLogger.minimum_log_level = LogLevel.ERROR
+    config = build_config(settings)
+    async with Ditto.open(config) as peer:
+        peer.set_offline_only_license_token(settings.offline_token or "")
+        peer.sync.start()
+
+        changes: asyncio.Queue[list[dict[str, Any]]] = asyncio.Queue()
+
+        def on_change(result: QueryResult) -> None:
+            try:
+                changes.put_nowait([item.value for item in result])
+            finally:
+                result.close()
+
+        subscription = peer.sync.register_subscription(SUBSCRIPTION_QUERY)
+        observer = peer.store.register_observer(TASKS_QUERY, on_change)
+        try:
+            print("Initial tasks:", await asyncio.wait_for(changes.get(), timeout=5))
+            task = {
+                "_id": str(uuid.uuid4()),
+                "title": "Buy milk",
+                "done": False,
+                "deleted": False,
+            }
+            with await peer.store.execute(
+                "INSERT INTO tasks DOCUMENTS (:task)", {"task": task}
+            ):
+                pass
+            observed = await asyncio.wait_for(changes.get(), timeout=5)
+            print("After insert:", observed)
+            assert any(t["title"] == "Buy milk" for t in observed), "inserted task not observed"
+            print("SMOKE OK")
+        finally:
+            observer.cancel()
+            observer.close()
+            subscription.cancel()
+            subscription.close()
+    return 0
+
+
+def cli(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Ditto Python Tasks quickstart.")
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="Run a non-interactive offline insert/observe check and exit.",
+    )
+    args = parser.parse_args(argv)
+
+    settings = load_settings(force_offline=args.smoke)
+    persistence_directory = settings.persistence_directory
+    try:
+        if args.smoke:
+            return asyncio.run(run_smoke(settings))
+        return asyncio.run(run_tui(settings))
+    finally:
+        shutil.rmtree(persistence_directory, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(cli())

--- a/python-tui/pyproject.toml
+++ b/python-tui/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "ditto-quickstart-python-tui"
+version = "0.1.0"
+description = "Ditto Python SDK quickstart — a Tasks console app that syncs peer-to-peer."
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "dittolive-ditto>=5.1.0.dev0",
+    "python-dotenv>=1.0.0",
+]
+
+[project.scripts]
+ditto-tasks = "main:cli"
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+py-modules = ["main"]


### PR DESCRIPTION
## Overview

Two Python SDK quickstarts:

- **python-tui** — the canonical cross-SDK "Tasks" console app (cloud + offline),
  matching `go-tui` / `rust-tui` / `javascript-tui`.
- **python-ros2** — three canonical ROS 2 demos bridged through Ditto, showing
  Ditto as a shared-state layer instead of DDS pub/sub:
  - talker/listener across **separate ROS graphs** joined only by Ditto;
  - teleop `cmd_vel` command/control over the mesh;
  - a **fleet sharing one CRDT world model** via a Ditto collection.

Both run with no ROS 2 install via an in-process `rclpy` shim (`--sim`); the
ROS 2 demos have a real-ROS 2 Docker path. `just python-tui` / `just python-ros2
<demo>` wire them in.

## Testing

`ditto-ros2 all --sim` runs all three demos end-to-end; the smoke tests
(`python-ros2/tests`) assert each one actually synced via Ditto (3 passed with an
offline token). The Tasks app follows the shared quickstart schema.

## Linked issues

Companion to the Python SDK work in getditto/ditto#24476.

## AI assistance

AI-assisted (Claude Code), human-supervised. Examples + bridge were AI-written
and verified running in `--sim`; a human directed and reviewed. `python-tui` came
from the same effort — please give it a quick review before marking ready.
