### PR TITLE
chore: publish Quickstarts for SDK version 5.1.0

### DIFF
--- a/android-java/gradle/libs.versions.toml
+++ b/android-java/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-ditto = "5.0.3"
+ditto = "5.1.0"
 agp = "8.7.3"
 kotlin = "2.0.0"
 coreKtx = "1.10.1"

--- a/android-kotlin/QuickStartTasks/gradle/libs.versions.toml
+++ b/android-kotlin/QuickStartTasks/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ appcompat = "1.7.1"
 datastorePreferences = "1.2.1"
 koin-bom = "4.2.1"
 coroutines-tests = "1.10.2"
-ditto = "5.0.3"
+ditto = "5.1.0"
 monitor = "1.8.0"
 json = "20240303"
 

--- a/cpp-tui/taskscpp/Makefile
+++ b/cpp-tui/taskscpp/Makefile
@@ -2,7 +2,7 @@
 BUILD_TYPE ?= Debug
 
 # Ditto SDK version and platform detection
-DITTO_SDK_VERSION ?= 5.0.3
+DITTO_SDK_VERSION ?= 5.1.0
 PLATFORM := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH := $(shell uname -m)
 

--- a/dotnet-maui/DittoMauiTasksApp/DittoMauiTasksApp.csproj
+++ b/dotnet-maui/DittoMauiTasksApp/DittoMauiTasksApp.csproj
@@ -52,7 +52,7 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.1" />
-        <PackageReference Include="Ditto" Version="5.0.3" />
+        <PackageReference Include="Ditto" Version="5.1.0" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
         <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
         <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />

--- a/dotnet-tui/DittoDotNetTasksConsole.Tests/DittoDotNetTasksConsole.Tests.csproj
+++ b/dotnet-tui/DittoDotNetTasksConsole.Tests/DittoDotNetTasksConsole.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageReference Include="Ditto" Version="5.0.3" />
+    <PackageReference Include="Ditto" Version="5.1.0" />
     <PackageReference Include="Terminal.Gui" Version="1.17.1" />
   </ItemGroup>
 

--- a/dotnet-tui/DittoDotNetTasksConsole/DittoDotNetTasksConsole.csproj
+++ b/dotnet-tui/DittoDotNetTasksConsole/DittoDotNetTasksConsole.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ditto" Version="5.0.3" />
+    <PackageReference Include="Ditto" Version="5.1.0" />
     <PackageReference Include="Terminal.Gui" Version="1.17.1" />
   </ItemGroup>
 

--- a/dotnet-winforms-net48/Taskapp.WinForms.Net48.csproj
+++ b/dotnet-winforms-net48/Taskapp.WinForms.Net48.csproj
@@ -43,17 +43,17 @@
          prerelease builds like 5.0.0-rc.1 (4-part fusion versions cannot
          encode a prerelease suffix). -->
     <Reference Include="Ditto">
-      <HintPath>packages\Ditto.5.0.3\lib\netstandard2.0\Ditto.dll</HintPath>
+      <HintPath>packages\Ditto.5.1.0\lib\netstandard2.0\Ditto.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Ditto.Native.Linux, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ditto.Native.Linux.5.0.3\lib\netstandard2.0\Ditto.Native.Linux.dll</HintPath>
+      <HintPath>packages\Ditto.Native.Linux.5.1.0\lib\netstandard2.0\Ditto.Native.Linux.dll</HintPath>
     </Reference>
     <Reference Include="Ditto.Native.MacOS, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ditto.Native.MacOS.5.0.3\lib\netstandard2.0\Ditto.Native.MacOS.dll</HintPath>
+      <HintPath>packages\Ditto.Native.MacOS.5.1.0\lib\netstandard2.0\Ditto.Native.MacOS.dll</HintPath>
     </Reference>
     <Reference Include="Ditto.Native.Win, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Ditto.Native.Win.5.0.3\lib\netstandard2.0\Ditto.Native.Win.dll</HintPath>
+      <HintPath>packages\Ditto.Native.Win.5.1.0\lib\netstandard2.0\Ditto.Native.Win.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>

--- a/dotnet-winforms-net48/packages.config
+++ b/dotnet-winforms-net48/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Ditto" version="5.0.3" targetFramework="net48" />
-  <package id="Ditto.Native.Linux" version="5.0.3" targetFramework="net48" />
-  <package id="Ditto.Native.MacOS" version="5.0.3" targetFramework="net48" />
-  <package id="Ditto.Native.Win" version="5.0.3" targetFramework="net48" />
+  <package id="Ditto" version="5.1.0" targetFramework="net48" />
+  <package id="Ditto.Native.Linux" version="5.1.0" targetFramework="net48" />
+  <package id="Ditto.Native.MacOS" version="5.1.0" targetFramework="net48" />
+  <package id="Ditto.Native.Win" version="5.1.0" targetFramework="net48" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net48" />
   <package id="Microsoft.Bcl.HashCode" version="1.1.1" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net48" />

--- a/dotnet-winforms/IntegrationTest/IntegrationTest.csproj
+++ b/dotnet-winforms/IntegrationTest/IntegrationTest.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ditto" Version="5.0.0" />
+    <PackageReference Include="Ditto" Version="5.1.0" />
     <PackageReference Include="System.Text.Json" Version="9.0.4" />
   </ItemGroup>
 

--- a/dotnet-winforms/IntegrationTest/Program.cs
+++ b/dotnet-winforms/IntegrationTest/Program.cs
@@ -59,7 +59,11 @@ class Program
                 return 1;
             }
 
-            var serverUrl = envVars.GetValueOrDefault("DITTO_SERVER_URL", "https://auth.cloud.ditto.live");
+            if (!envVars.TryGetValue("DITTO_SERVER_URL", out var serverUrl) || string.IsNullOrEmpty(serverUrl))
+            {
+                Console.WriteLine("❌ Missing DITTO_SERVER_URL in .env file");
+                return 1;
+            }
 
             Console.WriteLine($"📡 Connecting to Ditto (Database ID: {databaseId})");
 

--- a/dotnet-winforms/TasksApp/DittoTasksApp.csproj
+++ b/dotnet-winforms/TasksApp/DittoTasksApp.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ditto" Version="5.0.3" />
+    <PackageReference Include="Ditto" Version="5.1.0" />
     <PackageReference Include="System.Text.Json" Version="9.0.4" />
   </ItemGroup>
 

--- a/electron/package.json
+++ b/electron/package.json
@@ -20,7 +20,7 @@
     "format": "prettier --write ."
   },
   "dependencies": {
-    "@dittolive/ditto": "5.0.3",
+    "@dittolive/ditto": "5.1.0",
     "dotenv": "^16.4.5"
   },
   "devDependencies": {

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  ditto_live: 5.0.3
+  ditto_live: 5.1.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/java-server/build.gradle.kts
+++ b/java-server/build.gradle.kts
@@ -31,29 +31,29 @@ spotbugs {
 
 dependencies {
     // ditto-java artifact includes the Java API for Ditto
-    implementation("com.ditto:ditto-java:5.0.3")
+    implementation("com.ditto:ditto-java:5.1.0")
 
     // This will include binaries for all the supported platforms and architectures
-    implementation("com.ditto:ditto-binaries:5.0.3")
+    implementation("com.ditto:ditto-binaries:5.1.0")
 
     // To reduce your module artifact's size, consider including just the necessary platforms and architectures
     /*
         // macOS Apple Silicon
-        implementation("com.ditto:ditto-binaries:5.0.3") {
+        implementation("com.ditto:ditto-binaries:5.1.0") {
             capabilities {
                 requireCapability("com.ditto:ditto-binaries-macos-arm64")
             }
         }
 
         // Windows x86_64
-        implementation("com.ditto:ditto-binaries:5.0.3") {
+        implementation("com.ditto:ditto-binaries:5.1.0") {
             capabilities {
                 requireCapability("com.ditto:ditto-binaries-windows-x64")
             }
         }
 
         // Linux x86_64
-        implementation("com.ditto:ditto-binaries:5.0.3") {
+        implementation("com.ditto:ditto-binaries:5.1.0") {
             capabilities {
                 requireCapability("com.ditto:ditto-binaries-linux-x64")
             }

--- a/java-server/java-spring-maven/pom.xml
+++ b/java-server/java-spring-maven/pom.xml
@@ -34,14 +34,14 @@
         <dependency>
             <groupId>com.ditto</groupId>
             <artifactId>ditto-java</artifactId>
-            <version>5.0.3</version>
+            <version>5.1.0</version>
         </dependency>
 
 <!--    This will include binaries for all the supported platforms and architectures-->
         <dependency>
             <groupId>com.ditto</groupId>
             <artifactId>ditto-binaries</artifactId>
-            <version>5.0.3</version>
+            <version>5.1.0</version>
         </dependency>
 
 <!--    To reduce your module artifact's size, consider including just the necessary platforms and architectures-->

--- a/javascript-tui/package.json
+++ b/javascript-tui/package.json
@@ -20,7 +20,7 @@
     "dist"
   ],
   "dependencies": {
-    "@dittolive/ditto": "5.0.3",
+    "@dittolive/ditto": "5.1.0",
     "dotenv": "^16.4.5",
     "ink": "^4.1.0",
     "meow": "^11.0.0",

--- a/javascript-web/README.md
+++ b/javascript-web/README.md
@@ -28,7 +28,7 @@ From the repo root, copy the `.env.sample` file to `.env`, and fill in the
 fields with your Database ID and Development Token:
 
 ```
-cp .sample.env .env
+cp .env.sample .env
 ```
 
 The `.env` file should look like this (with your fields filled in):

--- a/javascript-web/package.json
+++ b/javascript-web/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@dittolive/ditto": "5.0.3",
+    "@dittolive/ditto": "5.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/kotlin-multiplatform/composeApp/build.gradle.kts
+++ b/kotlin-multiplatform/composeApp/build.gradle.kts
@@ -55,7 +55,7 @@ kotlin {
             }
         }
         commonMain.dependencies {
-            implementation("com.ditto:ditto-kotlin:5.0.3")
+            implementation("com.ditto:ditto-kotlin:5.1.0")
 
             implementation(compose.runtime)
             implementation(compose.foundation)
@@ -95,26 +95,26 @@ kotlin {
             implementation(libs.kotlinx.coroutines.swing)
 
             // This will include binaries for all the supported platforms and architectures
-            implementation("com.ditto:ditto-binaries:5.0.3")
+            implementation("com.ditto:ditto-binaries:5.1.0")
 
             // To reduce your module artifact's size, consider including just the necessary platforms and architectures
             /*
             // macOS Apple Silicon
-            implementation("com.ditto:ditto-binaries:5.0.3") {
+            implementation("com.ditto:ditto-binaries:5.1.0") {
                 capabilities {
                     requireCapability("com.ditto:ditto-binaries-macos-arm64")
                 }
             }
 
             // Windows x86_64
-            implementation("com.ditto:ditto-binaries:5.0.3") {
+            implementation("com.ditto:ditto-binaries:5.1.0") {
                 capabilities {
                     requireCapability("com.ditto:ditto-binaries-windows-x64")
                 }
             }
 
             // Linux x86_64
-            implementation("com.ditto:ditto-binaries:5.0.3") {
+            implementation("com.ditto:ditto-binaries:5.1.0") {
                 capabilities {
                     requireCapability("com.ditto:ditto-binaries-linux-x64")
                 }

--- a/react-native-expo/package.json
+++ b/react-native-expo/package.json
@@ -17,7 +17,7 @@
     "preset": "jest-expo"
   },
   "dependencies": {
-    "@dittolive/ditto": "5.0.3",
+    "@dittolive/ditto": "5.1.0",
     "@expo/vector-icons": "^15.0.3",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/native": "^7.1.8",

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -15,7 +15,7 @@
     "clean": "rm -rf node_modules && yarn install && cd ios && rm -rf Podfile.lock && rm -rf Pods && pod install && cd .."
   },
   "dependencies": {
-    "@dittolive/ditto": "5.0.3",
+    "@dittolive/ditto": "5.1.0",
     "react": "19.1.1",
     "react-native": "0.82.1",
     "react-native-bouncy-checkbox": "^4.1.2",

--- a/rust-tui/Cargo.toml
+++ b/rust-tui/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/bin/integration_test.rs"
 
 [dependencies]
 # Ditto dependencies
-dittolive-ditto = "=5.0.3"
+dittolive-ditto = "=5.1.0"
 
 # External dependencies
 anyhow = "1"

--- a/swift/Tasks.xcodeproj/project.pbxproj
+++ b/swift/Tasks.xcodeproj/project.pbxproj
@@ -540,7 +540,7 @@
 			repositoryURL = "https://github.com/getditto/DittoSwiftPackage";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 5.0.3;
+				minimumVersion = 5.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/swift/Tasks.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/swift/Tasks.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftPackage",
       "state" : {
-        "revision" : "1b18de5b8ea4c9148531af0a23407d0ef687b78d",
-        "version" : "5.0.2"
+        "revision" : "ec9682a4ab4e96484c5029feacb11fc7f78dfec3",
+        "version" : "5.1.0"
       }
     }
   ],


### PR DESCRIPTION
Publishes the Quickstart apps for SDK version 5.1.0. Opened automatically by the Quickstart Publish workflow.